### PR TITLE
Feature/vot 70 be setup google auth

### DIFF
--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -2,7 +2,8 @@
 using Microsoft.AspNetCore.Mvc;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models.Auth;
-using System.Security.Claims;
+using SelfGuidedTours.Core.Models.ExternalLogin;
+using System.Net.Http.Headers;
 
 namespace SelfGuidedTours.Api.Controllers
 {
@@ -12,11 +13,13 @@ namespace SelfGuidedTours.Api.Controllers
     {
         private readonly IAuthService authService;
         private readonly ILogger<AuthController> logger;
+        private readonly IGoogleAuthService googleAuthService;
 
-        public AuthController(IAuthService authService, ILogger<AuthController> logger)
+        public AuthController(IAuthService authService, ILogger<AuthController> logger, IGoogleAuthService googleAuthService)
         {
             this.authService = authService;
             this.logger = logger;
+            this.googleAuthService = googleAuthService;
         }
 
         [HttpPost("register")]
@@ -141,5 +144,32 @@ namespace SelfGuidedTours.Api.Controllers
         {
             return Ok("User is logged in.");
         }
+
+        
+        [HttpPost("google-signin")]
+        public async Task<IActionResult> HandleGoogleToken([FromBody] GoogleSignInVM model)
+        {
+            if (model == null || string.IsNullOrEmpty(model.IdToken))
+            {
+                return BadRequest("Invalid access token.");
+            }
+
+            try
+            {
+            var userInfo = await googleAuthService.GoogleSignIn(model);
+                return Ok(userInfo);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+
+
+        }
+
+
+
+      
+
     }
 }

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -15,12 +15,13 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+        public static IServiceCollection AddApplicationServices(this IServiceCollection services, IConfiguration config)
         {
             //Inject services here
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<IEmailService, EmailService>();
             services.AddScoped<IRefreshTokenService, RefreshTokenService>();
+            services.AddScoped<IGoogleAuthService, GoogleAuthService>();
 
             //Token generators
             services.AddScoped<AccessTokenGenerator>();
@@ -28,17 +29,19 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<TokenGenerator>();
             services.AddScoped<RefreshTokenValidator>();
 
-          
-             services.AddCors(Options =>
-            {
-                Options.AddPolicy("CorsPolicy", builder =>
-                {
-                    builder.WithOrigins("http://localhost:3000") // This is the Client app URL TODO: Change this after FE deployment
-                    .AllowAnyMethod()
-                    .AllowAnyHeader();
-                });
-            });
-          
+
+            services.AddCors(Options =>
+           {
+               Options.AddPolicy("CorsPolicy", builder =>
+               {
+                   builder
+                   .WithOrigins("http://localhost:3000") // This is the Client app URL TODO: Change this after FE deployment
+                   .AllowAnyMethod()
+                   .AllowCredentials()
+                   .AllowAnyHeader();
+               });
+           });
+
 
             return services;
         }
@@ -99,6 +102,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         ClockSkew = TimeSpan.Zero
                     };
                 });
+
 
             return services;
         }

--- a/SelfGuidedTours.Api/Program.cs
+++ b/SelfGuidedTours.Api/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddApplicationDbContext(builder.Configuration);
 
 builder.Services.AddApplicationIdentity(builder.Configuration);
 
-builder.Services.AddApplicationServices();
+builder.Services.AddApplicationServices(builder.Configuration);
 
 builder.Services.AddSwaggerGen(options =>
 {

--- a/SelfGuidedTours.Core/Contracts/IAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IAuthService.cs
@@ -1,4 +1,5 @@
 ﻿using SelfGuidedTours.Core.Models.Auth;
+using SelfGuidedTours.Core.Models.ExternalLogin;
 
 namespace SelfGuidedTours.Core.Contracts
 {
@@ -8,5 +9,6 @@ namespace SelfGuidedTours.Core.Contracts
         Task<AuthenticateResponse> LoginAsync(LoginInputModel model);
         Task LogoutAsync(string userId);
         Task<AuthenticateResponse> RefreshAsync(RefreshRequestModel model);
+        Task<AuthenticateResponse> GoogleSignInAsync(GoogleUserDto googleUser);
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IGoogleAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IGoogleAuthService.cs
@@ -1,0 +1,16 @@
+﻿using SelfGuidedTours.Core.Models.Auth;
+using SelfGuidedTours.Core.Models.ExternalLogin;
+using SelfGuidedTours.Infrastructure.Data.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SelfGuidedTours.Core.Contracts
+{
+    public interface IGoogleAuthService
+    {
+        Task<AuthenticateResponse> GoogleSignIn(GoogleSignInVM model);
+    }
+}

--- a/SelfGuidedTours.Core/Models/ExternalLogin/GoogleAuthConfig.cs
+++ b/SelfGuidedTours.Core/Models/ExternalLogin/GoogleAuthConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace SelfGuidedTours.Core.Models.ExternalLogin
+{
+    public class GoogleAuthConfig
+    {
+        public string ClientId { get; set; } = null!;
+        public string ClientSecret { get; set; } = null!;
+    }
+}

--- a/SelfGuidedTours.Core/Models/ExternalLogin/GoogleSignInVM.cs
+++ b/SelfGuidedTours.Core/Models/ExternalLogin/GoogleSignInVM.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace SelfGuidedTours.Core.Models.ExternalLogin
+{
+    public class GoogleSignInVM
+    {
+        [Required]
+        public string IdToken { get; set; } = null!;
+    }
+}

--- a/SelfGuidedTours.Core/Models/ExternalLogin/GoogleUserDto.cs
+++ b/SelfGuidedTours.Core/Models/ExternalLogin/GoogleUserDto.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SelfGuidedTours.Core.Models.ExternalLogin
+{
+    public class GoogleUserDto
+    {
+        public string Id { get; set; } = null!;
+        public string Email { get; set; } = null!;
+        public string Name { get; set; } = null!;
+        public string Picture { get; set; } = null!;
+    }
+}

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -131,6 +131,11 @@ namespace SelfGuidedTours.Core.Services
         }
         public async Task<AuthenticateResponse> GoogleSignInAsync(GoogleUserDto googleUser)
         {
+            if (googleUser == null)
+            {
+                throw new ArgumentException("Invalid Google Id Token");
+            }
+
             var user = await GetByEmailAsync(googleUser.Email);
 
             if (user == null)

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -144,7 +144,7 @@ namespace SelfGuidedTours.Core.Services
                 {
                     Email = googleUser.Email,
                     UserName = googleUser.Email,
-                    Name = googleUser.Name
+                    Name = googleUser.Name,
                 };
                 var userRole = AssignUserRole(user.Id);
 

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models.Auth;
+using SelfGuidedTours.Core.Models.ExternalLogin;
 using SelfGuidedTours.Core.Services.TokenGenerators;
 using SelfGuidedTours.Core.Services.TokenValidators;
 using SelfGuidedTours.Infrastructure.Common;
@@ -100,11 +101,8 @@ namespace SelfGuidedTours.Core.Services
                 PasswordHash = hasher.HashPassword(null!, model.Password) // Hash the password
             };
             //Assign user role
-            var userRole = new IdentityUserRole<string>
-            {
-                UserId = user.Id,
-                RoleId = "4f8554d2-cfaa-44b5-90ce-e883c804ae90" //User Role Id
-            };
+            var userRole = AssignUserRole(user.Id);
+
 
             await repository.AddAsync(user);
             await repository.AddAsync(userRole);
@@ -131,7 +129,27 @@ namespace SelfGuidedTours.Core.Services
 
             return await AuthenticateAsync(user, "Successfully logged in!");
         }
+        public async Task<AuthenticateResponse> GoogleSignInAsync(GoogleUserDto googleUser)
+        {
+            var user = await GetByEmailAsync(googleUser.Email);
 
+            if (user == null)
+            {
+                user = new ApplicationUser
+                {
+                    Email = googleUser.Email,
+                    UserName = googleUser.Email,
+                    Name = googleUser.Name
+                };
+                var userRole = AssignUserRole(user.Id);
+
+                await repository.AddAsync(userRole);
+                await repository.AddAsync(user);
+                await repository.SaveChangesAsync();
+            }
+
+            return await AuthenticateAsync(user, "Successfully logged in!");
+        }
         public async Task LogoutAsync(string userId)
         {
             await refreshTokenService.DeleteAllAsync(userId);
@@ -164,6 +182,13 @@ namespace SelfGuidedTours.Core.Services
 
             return await AuthenticateAsync(user, "Successfully got new tokens!");
         }
-
+        private IdentityUserRole<string> AssignUserRole(string userId)
+        {
+            return new IdentityUserRole<string>
+            {
+                UserId = userId,
+                RoleId = "4f8554d2-cfaa-44b5-90ce-e883c804ae90" //User Role Id
+            };
+        }
     }
 }

--- a/SelfGuidedTours.Core/Services/GoogleAuthService.cs
+++ b/SelfGuidedTours.Core/Services/GoogleAuthService.cs
@@ -24,7 +24,11 @@ namespace SelfGuidedTours.Core.Services
             {
                 PropertyNameCaseInsensitive = true
             });
-           
+            if (googleUser == null)
+            {
+                throw new Exception("Invalid Google Id Token");
+            }
+
             var userResponse = await authService.GoogleSignInAsync(googleUser);
 
             return userResponse;

--- a/SelfGuidedTours.Core/Services/GoogleAuthService.cs
+++ b/SelfGuidedTours.Core/Services/GoogleAuthService.cs
@@ -1,0 +1,48 @@
+﻿using SelfGuidedTours.Core.Contracts;
+using SelfGuidedTours.Core.Models.Auth;
+using SelfGuidedTours.Core.Models.ExternalLogin;
+using System.Net.Http.Headers;
+using System.Text.Json;
+namespace SelfGuidedTours.Core.Services
+{
+    public class GoogleAuthService : IGoogleAuthService
+    {
+        private readonly IAuthService authService;
+
+        public GoogleAuthService(IAuthService authService)
+        {
+            this.authService = authService;
+        }
+        public async Task<AuthenticateResponse> GoogleSignIn(GoogleSignInVM model)
+        {
+            var payload = await ValidateGoogleIdToken(model.IdToken);
+            if (payload == null)
+            {
+                throw new Exception("Invalid Google Id Token");
+            }
+            var googleUser = JsonSerializer.Deserialize<GoogleUserDto>(payload, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+           
+            var userResponse = await authService.GoogleSignInAsync(googleUser);
+
+            return userResponse;
+        }
+        private async Task<string?> ValidateGoogleIdToken(string idToken)
+        {
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", idToken);
+
+            var response = await httpClient.GetAsync("https://www.googleapis.com/oauth2/v2/userinfo");
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            var userInfo = await response.Content.ReadAsStringAsync();
+
+            return userInfo;
+        }
+    }
+}


### PR DESCRIPTION
Add endpoint for google-signin, add logic to recieve a google id token and validate it, if the token is valid we get info about the user through the google api. If this is the first google login of the user, we create a new user in the database, if its not we just log him in with the existing one. At the moment if there is an account registered wit a google email, upon external login with google the user will be logged in with the existing accout. I think at a later point  we should figure out a way to inform the user, and ask him if he wants that.