### PR TITLE
Feature/vot 106 add global try catch middleware

### DIFF
--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
                Options.AddPolicy("CorsPolicy", builder =>
                {
                    builder
-                   .WithOrigins("http://localhost:3000") // This is the Client app URL TODO: Change this after FE deployment
+                   .WithOrigins("http://localhost:3000", "https://self-guided-tour-fe.vercel.app/") // This will work for the local enviroment and with the current deployment URL
                    .AllowAnyMethod()
                    .AllowCredentials()
                    .AllowAnyHeader();

--- a/SelfGuidedTours.Api/Middlewares/ExceptionHandlerMiddleware.cs
+++ b/SelfGuidedTours.Api/Middlewares/ExceptionHandlerMiddleware.cs
@@ -1,0 +1,88 @@
+﻿using System.Net;
+using System.Text.Json;
+
+namespace SelfGuidedTours.Api.Middlewares
+{
+    public class ExceptionHandlerMiddleware
+    {
+        private readonly ILogger<ExceptionHandlerMiddleware> logger;
+        private readonly RequestDelegate next;  // This calls the next middleware in the pipeline
+
+        public ExceptionHandlerMiddleware(ILogger<ExceptionHandlerMiddleware> logger, RequestDelegate next)
+        {
+            this.logger = logger;
+            this.next = next;
+        }
+        //Impelement the InvokeAsync method by convention
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+            try
+            {
+                await next(httpContext);
+            }
+            catch(ArgumentException ex)
+            {
+                logger.LogError($"Invalid argument: {ex} ");
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.BadRequest);
+            }
+            catch (InvalidOperationException ex)
+            {
+                logger.LogError($"Invalid operation: {ex} ");
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.BadRequest);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                logger.LogError($"Unauthorized access: {ex} ");
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.Unauthorized);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                logger.LogError($"Key not found: {ex} ");
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.NotFound);
+            }
+            catch (TimeoutException ex)
+            {
+                logger.LogError($"Request timed out: {ex} ");
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.RequestTimeout);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"Unexpected error: {ex} ");
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.InternalServerError);
+            }
+        }
+        /// <summary>
+        /// Creates a response with the error details
+        /// </summary>
+        /// <param name="context"> HTTP Context</param>
+        /// <param name="exception">The caught exception, that needs to be handled</param>
+        /// <param name="statusCode">The HTTP status code that gets converted to int</param>
+        private Task HandleExceptionAsync(HttpContext context, Exception exception, HttpStatusCode statusCode)
+        {
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)statusCode;
+
+            return context.Response.WriteAsync(new ErrorDetails()
+            {
+                ErrorId = Guid.NewGuid(),
+                StatusCode = context.Response.StatusCode,
+                Message = exception.Message
+            }.ToString());
+        }
+
+        /// <summary>
+        /// A class that holds the error details
+        /// </summary>
+        private class ErrorDetails
+        {
+            public Guid ErrorId { get; set; }
+            public int StatusCode { get; set; }
+            public string Message { get; set; } = string.Empty;
+
+            public override string ToString()
+            {
+                return JsonSerializer.Serialize(this);
+            }
+        }
+    }
+}

--- a/SelfGuidedTours.Api/Middlewares/ExceptionHandlerMiddleware.cs
+++ b/SelfGuidedTours.Api/Middlewares/ExceptionHandlerMiddleware.cs
@@ -22,33 +22,39 @@ namespace SelfGuidedTours.Api.Middlewares
             }
             catch(ArgumentException ex)
             {
+                string errorType = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.1";
                 logger.LogError($"Invalid argument: {ex} ");
-                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.BadRequest);
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.BadRequest, errorType);
             }
             catch (InvalidOperationException ex)
             {
+                string errorType = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.1";
                 logger.LogError($"Invalid operation: {ex} ");
-                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.BadRequest);
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.BadRequest, errorType);
             }
             catch (UnauthorizedAccessException ex)
             {
+                string errorType = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.2";
                 logger.LogError($"Unauthorized access: {ex} ");
-                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.Unauthorized);
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.Unauthorized, errorType);
             }
             catch (KeyNotFoundException ex)
             {
+                string errorType = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.5";
                 logger.LogError($"Key not found: {ex} ");
-                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.NotFound);
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.NotFound, errorType);
             }
             catch (TimeoutException ex)
             {
+                string errorType = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.9";
                 logger.LogError($"Request timed out: {ex} ");
-                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.RequestTimeout);
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.RequestTimeout, errorType);
             }
             catch (Exception ex)
             {
+                string errorType = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.1";
                 logger.LogError($"Unexpected error: {ex} ");
-                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.InternalServerError);
+                await HandleExceptionAsync(httpContext, ex, HttpStatusCode.InternalServerError, errorType);
             }
         }
         /// <summary>
@@ -57,7 +63,8 @@ namespace SelfGuidedTours.Api.Middlewares
         /// <param name="context"> HTTP Context</param>
         /// <param name="exception">The caught exception, that needs to be handled</param>
         /// <param name="statusCode">The HTTP status code that gets converted to int</param>
-        private Task HandleExceptionAsync(HttpContext context, Exception exception, HttpStatusCode statusCode)
+        /// <param name="errorType">The type of the error and a link to documentation about it, following REST principals</param>
+        private Task HandleExceptionAsync(HttpContext context, Exception exception, HttpStatusCode statusCode, string errorType)
         {
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = (int)statusCode;
@@ -66,7 +73,8 @@ namespace SelfGuidedTours.Api.Middlewares
             {
                 ErrorId = Guid.NewGuid(),
                 StatusCode = context.Response.StatusCode,
-                Message = exception.Message
+                Message = exception.Message,
+                Type = errorType
             }.ToString());
         }
 
@@ -78,7 +86,10 @@ namespace SelfGuidedTours.Api.Middlewares
             public Guid ErrorId { get; set; }
             public int StatusCode { get; set; }
             public string Message { get; set; } = string.Empty;
+            public string Type { get; set; } = string.Empty;
 
+
+            //Override the ToString method to return the object as a JSON string
             public override string ToString()
             {
                 return JsonSerializer.Serialize(this);

--- a/SelfGuidedTours.Api/Program.cs
+++ b/SelfGuidedTours.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi.Models;
+using SelfGuidedTours.Api.Middlewares;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -53,6 +54,9 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+// Add custom middleware for exception handling to the pipeline
+app.UseMiddleware<ExceptionHandlerMiddleware>(); 
 
 app.UseCors("CorsPolicy"); // apply CORS policy from ServiceCollectionExtensions.cs
 app.UseHttpsRedirection();

--- a/SelfGuidedTours.Common/ValidationConstants/AuthConstants.cs
+++ b/SelfGuidedTours.Common/ValidationConstants/AuthConstants.cs
@@ -9,7 +9,14 @@
         {
             public const int PasswordMinLength = 6;
 
+            public const string InvalidPasswordMessage = "Password must contain at least 6 characters, one uppercase letter, one lowercase letter, one digit and one special character!";
+
             public const string PasswordsDoNotMatchMessage = "Passwords do not match!";
+
+            public const string EmailRegex = @"^([\w\.\-]+)@([\w\-]+)((\.(\w){2,})+)$";
+
+            public const string PasswordRegex = @"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{6,}$";
+
         }
     }
 }

--- a/SelfGuidedTours.Core/Models/Auth/RegisterInputModel.cs
+++ b/SelfGuidedTours.Core/Models/Auth/RegisterInputModel.cs
@@ -7,17 +7,19 @@ namespace SelfGuidedTours.Core.Models.Auth
     public class RegisterInputModel
     {
         [Display(Name = nameof(Email))]
+        [EmailAddress]
         [Required(ErrorMessage = RequiredMessage)]
-        [EmailAddress(ErrorMessage = InvalidEmailAddressMessage)]
+        [RegularExpression(EmailRegex, ErrorMessage = InvalidEmailAddressMessage)]
         public string Email { get; set; } = null!;
 
         [Display(Name = nameof(Name))]
         [Required(ErrorMessage = RequiredMessage)]
         public string Name { get; set; } = null!;
 
-        [Display(Name = nameof(Password))]
         [Required(ErrorMessage = RequiredMessage)]
+        [Display(Name = nameof(Password))]
         [MinLength(PasswordMinLength, ErrorMessage = LengthErrorMessage)]
+        [RegularExpression(PasswordRegex, ErrorMessage = InvalidPasswordMessage)]
         public string Password { get; set; } = null!;
 
         [Display(Name = "Repeat Password")]


### PR DESCRIPTION
Add global try catch middleware to handle the most common exceptions and return an appropriate response. And add the FE doployment URL to the CORS policy. Also add email and password ReGex for data validation.
![TestException](https://github.com/Cost-Efficient-Software-Team/Self-Guided-Tour-BE/assets/52136757/540ba643-abb2-4fd7-861a-74b97da9c172)
