### PR TITLE
Add change password endpoint

### DIFF
--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models.Auth;
 using SelfGuidedTours.Core.Models.ExternalLogin;
 using System.Net.Http.Headers;
+using System.Security.Claims;
 
 namespace SelfGuidedTours.Api.Controllers
 {
@@ -168,6 +169,32 @@ namespace SelfGuidedTours.Api.Controllers
         }
 
 
+        [HttpPost("change-password")]
+        [ProducesResponseType(typeof(string), 200)]
+        [ProducesResponseType(typeof(string), 400)]
+        [ProducesResponseType(typeof(string), 401)]
+        [Authorize]
+        public async Task<IActionResult> ChgangePassword([FromBody] ChangePasswordRequestDto model)
+        {
+            if(!ModelState.IsValid)
+            {
+                logger.LogWarning("Invalid model state for change password request!");
+                return BadRequest("Invalid model state");
+            }
+
+            string userId = User.Claims.First().Value;
+
+            var changePasswordModel = new ChangePasswordModel
+            {
+                UserId = userId,
+                CurrentPassword = model.CurrentPassword,
+                NewPassword = model.NewPassword
+            };
+
+            var response = await authService.ChanghePasswordAsync(changePasswordModel);
+
+            return Ok(response);
+        }
 
       
 

--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SelfGuidedTours.Core.Contracts;
+using SelfGuidedTours.Core.Models;
 using SelfGuidedTours.Core.Models.Auth;
 using SelfGuidedTours.Core.Models.ExternalLogin;
 using System.Net.Http.Headers;
@@ -170,11 +171,11 @@ namespace SelfGuidedTours.Api.Controllers
 
 
         [HttpPost("change-password")]
-        [ProducesResponseType(typeof(string), 200)]
-        [ProducesResponseType(typeof(string), 400)]
-        [ProducesResponseType(typeof(string), 401)]
+        [ProducesResponseType(typeof(ApiResponse), 200)]
+        [ProducesResponseType(typeof(ApiResponse), 400)]
+        [ProducesResponseType(typeof(ApiResponse), 401)]
         [Authorize]
-        public async Task<IActionResult> ChgangePassword([FromBody] ChangePasswordRequestDto model)
+        public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequestDto model)
         {
             if(!ModelState.IsValid)
             {
@@ -191,7 +192,7 @@ namespace SelfGuidedTours.Api.Controllers
                 NewPassword = model.NewPassword
             };
 
-            var response = await authService.ChanghePasswordAsync(changePasswordModel);
+            var response = await authService.ChangePasswordAsync(changePasswordModel);
             // In case something goes wrong, an exception is thrown in the authService and it gets automaticaly caught from the middleware
 
             return Ok(response);

--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -192,6 +192,7 @@ namespace SelfGuidedTours.Api.Controllers
             };
 
             var response = await authService.ChanghePasswordAsync(changePasswordModel);
+            // In case something goes wrong, an exception is thrown in the authService and it gets automaticaly caught from the middleware
 
             return Ok(response);
         }

--- a/SelfGuidedTours.Api/Program.cs
+++ b/SelfGuidedTours.Api/Program.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi.Models;
-
 using SelfGuidedTours.Api.Extensions;
-
 using SelfGuidedTours.Api.Middlewares;
 
 

--- a/SelfGuidedTours.Core/Contracts/IAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IAuthService.cs
@@ -1,4 +1,5 @@
-﻿using SelfGuidedTours.Core.Models.Auth;
+﻿using SelfGuidedTours.Core.Models;
+using SelfGuidedTours.Core.Models.Auth;
 using SelfGuidedTours.Core.Models.ExternalLogin;
 
 namespace SelfGuidedTours.Core.Contracts
@@ -10,7 +11,7 @@ namespace SelfGuidedTours.Core.Contracts
         Task LogoutAsync(string userId);
         Task<AuthenticateResponse> RefreshAsync(RefreshRequestModel model);
         Task<AuthenticateResponse> GoogleSignInAsync(GoogleUserDto googleUser);
-        Task<AuthenticateResponse> ChanghePasswordAsync(ChangePasswordModel model);
+        Task<ApiResponse> ChanghePasswordAsync(ChangePasswordModel model);
         
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IAuthService.cs
@@ -10,5 +10,7 @@ namespace SelfGuidedTours.Core.Contracts
         Task LogoutAsync(string userId);
         Task<AuthenticateResponse> RefreshAsync(RefreshRequestModel model);
         Task<AuthenticateResponse> GoogleSignInAsync(GoogleUserDto googleUser);
+        Task<AuthenticateResponse> ChanghePasswordAsync(ChangePasswordModel model);
+        
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IAuthService.cs
@@ -11,7 +11,7 @@ namespace SelfGuidedTours.Core.Contracts
         Task LogoutAsync(string userId);
         Task<AuthenticateResponse> RefreshAsync(RefreshRequestModel model);
         Task<AuthenticateResponse> GoogleSignInAsync(GoogleUserDto googleUser);
-        Task<ApiResponse> ChanghePasswordAsync(ChangePasswordModel model);
+        Task<ApiResponse> ChangePasswordAsync(ChangePasswordModel model);
         
     }
 }

--- a/SelfGuidedTours.Core/Models/Auth/ChangePasswordModel.cs
+++ b/SelfGuidedTours.Core/Models/Auth/ChangePasswordModel.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+namespace SelfGuidedTours.Core.Models.Auth
+{
+    public class ChangePasswordModel
+    {
+        [Required]
+        public string UserId { get; set; } = null!;
+        [Required]
+        public string CurrentPassword { get; set; } = null!;
+        [Required]
+        public string NewPassword { get; set; } = null!;
+    }
+}

--- a/SelfGuidedTours.Core/Models/Auth/ChangePasswordRequestDto.cs
+++ b/SelfGuidedTours.Core/Models/Auth/ChangePasswordRequestDto.cs
@@ -5,10 +5,10 @@ namespace SelfGuidedTours.Core.Models.Auth
     public class ChangePasswordRequestDto
     {
         [Required]
-        public string CurrentPassword { get; set; }
+        public string CurrentPassword { get; set; } = null!;
         [Required]
-        [MinLength(PasswordMinLength,
-            ErrorMessage = InvalidPasswordMessage)]
+        [RegularExpression(PasswordRegex,
+        ErrorMessage = InvalidPasswordMessage)]
         public string NewPassword { get; set; } = null!;
     }
 }

--- a/SelfGuidedTours.Core/Models/Auth/ChangePasswordRequestDto.cs
+++ b/SelfGuidedTours.Core/Models/Auth/ChangePasswordRequestDto.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+using static SelfGuidedTours.Common.ValidationConstants.AuthConstants.Register;
+namespace SelfGuidedTours.Core.Models.Auth
+{
+    public class ChangePasswordRequestDto
+    {
+        [Required]
+        public string CurrentPassword { get; set; }
+        [Required]
+        [MinLength(PasswordMinLength,
+            ErrorMessage = InvalidPasswordMessage)]
+        public string NewPassword { get; set; } = null!;
+    }
+}

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -198,7 +198,7 @@ namespace SelfGuidedTours.Core.Services
             };
         }
 
-        public async Task<ApiResponse> ChanghePasswordAsync(ChangePasswordModel model)
+        public async Task<ApiResponse> ChangePasswordAsync(ChangePasswordModel model)
         {
             if (model.CurrentPassword == model.NewPassword) throw new ArgumentException("New password can't be the same as the current one!");
 

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -225,26 +225,5 @@ namespace SelfGuidedTours.Core.Services
             return response;
         }
 
-        public async Task<AuthenticateResponse> ChanghePasswordAsync(ChangePasswordModel model)
-        {
-            var user = await GetByIdAsync(model.UserId);
-
-            if (user is null) throw new UnauthorizedAccessException("User not found");
-            //User created via external login doesent have an assigned password
-            if (user.PasswordHash is null) throw new UnauthorizedAccessException("User has no assigned password!");
-
-            var hasher = new PasswordHasher<ApplicationUser>();
-
-            var result = hasher.VerifyHashedPassword(user, user.PasswordHash, model.CurrentPassword);
-
-            if (result != PasswordVerificationResult.Success) throw new UnauthorizedAccessException("Invalid password");
-            //Update the user's password with the new one
-            user.PasswordHash = hasher.HashPassword(user, model.NewPassword);
-
-            await repository.UpdateAsync(user);
-            await repository.SaveChangesAsync();
-            //TODO: Fix response
-            return new AuthenticateResponse();
-        }
     }
 }

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -50,10 +50,10 @@ namespace SelfGuidedTours.Core.Services
         {
             var handler = new JwtSecurityTokenHandler();
             var jwtSecurityToken = handler.ReadJwtToken(token);
-           
+
             var tokenExp = jwtSecurityToken.Claims.First(claim => claim.Type.Equals("exp")).Value;
             var ticks = long.Parse(tokenExp);
-            
+
             return ticks;
         }
 
@@ -69,7 +69,7 @@ namespace SelfGuidedTours.Core.Services
             };
 
             await refreshTokenService.CreateAsync(refreshTokenDTO);
-            
+
             return new AuthenticateResponse()
             {
                 AccessToken = accessToken,
@@ -170,7 +170,7 @@ namespace SelfGuidedTours.Core.Services
 
             var refreshTokenDTO = await refreshTokenService.GetByTokenAsync(model.RefreshToken);
 
-            if(refreshTokenDTO == null)
+            if (refreshTokenDTO == null)
             {
                 throw new ArgumentException("Refresh token was not found!");
             }
@@ -179,7 +179,7 @@ namespace SelfGuidedTours.Core.Services
 
             var user = await GetByIdAsync(refreshTokenDTO.UserId);
 
-            if(user == null)
+            if (user == null)
             {
                 throw new ArgumentException("User was not found!");
             }
@@ -193,6 +193,28 @@ namespace SelfGuidedTours.Core.Services
                 UserId = userId,
                 RoleId = "4f8554d2-cfaa-44b5-90ce-e883c804ae90" //User Role Id
             };
+        }
+
+        public async Task<AuthenticateResponse> ChanghePasswordAsync(ChangePasswordModel model)
+        {
+            var user = await GetByIdAsync(model.UserId);
+
+            if (user is null) throw new UnauthorizedAccessException("User not found");
+            //User created via external login doesent have an assigned password
+            if (user.PasswordHash is null) throw new UnauthorizedAccessException("User has no assigned password!");
+
+            var hasher = new PasswordHasher<ApplicationUser>();
+
+            var result = hasher.VerifyHashedPassword(user, user.PasswordHash, model.CurrentPassword);
+
+            if (result != PasswordVerificationResult.Success) throw new UnauthorizedAccessException("Invalid password");
+            //Update the user's password with the new one
+            user.PasswordHash = hasher.HashPassword(user, model.NewPassword);
+
+            await repository.UpdateAsync(user);
+            await repository.SaveChangesAsync();
+            //TODO: Fix response
+            return new AuthenticateResponse();
         }
     }
 }

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using SelfGuidedTours.Core.Contracts;
+using SelfGuidedTours.Core.Models;
 using SelfGuidedTours.Core.Models.Auth;
 using SelfGuidedTours.Core.Models.ExternalLogin;
 using SelfGuidedTours.Core.Services.TokenGenerators;
@@ -8,6 +9,7 @@ using SelfGuidedTours.Core.Services.TokenValidators;
 using SelfGuidedTours.Infrastructure.Common;
 using SelfGuidedTours.Infrastructure.Data.Models;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 
 namespace SelfGuidedTours.Core.Services
 {
@@ -23,7 +25,8 @@ namespace SelfGuidedTours.Core.Services
             AccessTokenGenerator accessTokenGenerator,
             RefreshTokenGenerator refreshTokenGenerator,
             RefreshTokenValidator refreshTokenValidator,
-            IRefreshTokenService refreshTokenService)
+            IRefreshTokenService refreshTokenService
+            )
         {
             this.repository = repository;
             this.accessTokenGenerator = accessTokenGenerator;
@@ -195,7 +198,7 @@ namespace SelfGuidedTours.Core.Services
             };
         }
 
-        public async Task<AuthenticateResponse> ChanghePasswordAsync(ChangePasswordModel model)
+        public async Task<ApiResponse> ChanghePasswordAsync(ChangePasswordModel model)
         {
             var user = await GetByIdAsync(model.UserId);
 
@@ -214,7 +217,12 @@ namespace SelfGuidedTours.Core.Services
             await repository.UpdateAsync(user);
             await repository.SaveChangesAsync();
             //TODO: Fix response
-            return new AuthenticateResponse();
+            var response = new ApiResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Result = "Password changed successfully!"
+            };
+            return response;
         }
     }
 }

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -200,10 +200,12 @@ namespace SelfGuidedTours.Core.Services
 
         public async Task<ApiResponse> ChanghePasswordAsync(ChangePasswordModel model)
         {
+            if (model.CurrentPassword == model.NewPassword) throw new ArgumentException("New password can't be the same as the current one!");
+
             var user = await GetByIdAsync(model.UserId);
 
             if (user is null) throw new UnauthorizedAccessException("User not found");
-            //User created via external login doesent have an assigned password
+            //User created via external login doesent have an assigned password and shouldnt be able to acces this method
             if (user.PasswordHash is null) throw new UnauthorizedAccessException("User has no assigned password!");
 
             var hasher = new PasswordHasher<ApplicationUser>();


### PR DESCRIPTION
Implemented change password endpoint. The user must be logged in to change his password, he is asked for the current password and the new password. The new password gets the same validation as on user creation. If the provided current password is wrong or is the same as the new password an exception is thrown. 
  The user has to know the current password and has to be logged in and provide the acces token, at that point email validation is not needed, we will use email validation on the forgot password endpoint