### PR TITLE
Feature/vot 146 fix user already exists error response

### DIFF
--- a/SelfGuidedTours.Common/MessageConstants/ErrorMessages.cs
+++ b/SelfGuidedTours.Common/MessageConstants/ErrorMessages.cs
@@ -25,5 +25,7 @@
         public const string TourAlreadyApprovedErrorMessage = "Tour is already approved";
 
         public const string TourAlreadyRejectedErrorMessage = "Tour is already rejected";
+
+        public const string UserWithEmailAlreadyExistsErrorMessage = "User with this email already exists!";
     }
 }

--- a/SelfGuidedTours.Core/CustomExceptions/EmailAlreadyInUseException.cs
+++ b/SelfGuidedTours.Core/CustomExceptions/EmailAlreadyInUseException.cs
@@ -1,0 +1,11 @@
+﻿using static SelfGuidedTours.Common.MessageConstants.ErrorMessages;
+namespace SelfGuidedTours.Core.CustomExceptions
+{
+    public class EmailAlreadyInUseException : Exception
+    {
+        public EmailAlreadyInUseException() : base(UserWithEmailAlreadyExistsErrorMessage)
+        {
+
+        }
+    }
+}

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -61,9 +61,9 @@ namespace SelfGuidedTours.Core.Services
             var jwtSecurityToken = handler.ReadJwtToken(token);
 
             var tokenExp = jwtSecurityToken.Claims.First(claim => claim.Type.Equals("exp")).Value;
-            var ticks = long.Parse(tokenExp);
+            var ticsInMilliseconds = long.Parse(tokenExp) * 1000; // convert seconds to milliseconds, so it works with JS Date
 
-            return ticks;
+            return ticsInMilliseconds;
         }
 
         private async Task<AuthenticateResponse> AuthenticateAsync(ApplicationUser user, string responesMessage)

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SelfGuidedTours.Core.Contracts;
+using SelfGuidedTours.Core.CustomExceptions;
 using SelfGuidedTours.Core.Models;
 using SelfGuidedTours.Core.Models.Auth;
 using SelfGuidedTours.Core.Models.ExternalLogin;
@@ -91,7 +92,7 @@ namespace SelfGuidedTours.Core.Services
         {
             if (await GetByEmailAsync(model.Email) != null)
             {
-                throw new ArgumentException("User already exists!");
+                throw new EmailAlreadyInUseException();
             }
 
             if (model.Password != model.RepeatPassword)

--- a/SelfGuidedTours.Tests/SelfGuidedTours.Tests.csproj
+++ b/SelfGuidedTours.Tests/SelfGuidedTours.Tests.csproj
@@ -23,6 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\SelfGuidedTours.Api\SelfGuidedTours.Api.csproj" />
 		<ProjectReference Include="..\SelfGuidedTours.Core\SelfGuidedTours.Core.csproj" />
 		<ProjectReference Include="..\SelfGuidedTours.Infrastructure\SelfGuidedTours.Infrastructure.csproj" />
 	</ItemGroup>

--- a/SelfGuidedTours.Tests/UnitTests/AuthServiceTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/AuthServiceTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SelfGuidedTours.Core.Contracts;
+using SelfGuidedTours.Core.CustomExceptions;
 using SelfGuidedTours.Core.Models.Auth;
 using SelfGuidedTours.Core.Services;
 using SelfGuidedTours.Core.Services.TokenGenerators;
@@ -10,6 +11,7 @@ using SelfGuidedTours.Infrastructure.Common;
 using SelfGuidedTours.Infrastructure.Data;
 using SelfGuidedTours.Infrastructure.Data.Models;
 using System.Net;
+using static SelfGuidedTours.Common.MessageConstants.ErrorMessages;
 
 namespace SelfGuidedTours.Tests.UnitTests
 {
@@ -146,9 +148,9 @@ namespace SelfGuidedTours.Tests.UnitTests
             {
                 _ = await service.RegisterAsync(model);
             }
-            catch (ArgumentException ex)
+            catch (EmailAlreadyInUseException ex)
             {
-                Assert.That(ex.Message, Is.EqualTo("User already exists!"));
+                Assert.That(ex.Message, Is.EqualTo(UserWithEmailAlreadyExistsErrorMessage));
             }
         }
 

--- a/SelfGuidedTours.Tests/UnitTests/CustomExceptionTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/CustomExceptionTests.cs
@@ -1,0 +1,26 @@
+﻿using SelfGuidedTours.Core.CustomExceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SelfGuidedTours.Tests.UnitTests
+{
+    [TestFixture]
+    public class CustomExceptionTests
+    {
+        [Test]
+        public void EmailAlreadyInUseException_ShouldReturnErrorMessage()
+        {
+            // Arrange
+            var exception = new EmailAlreadyInUseException();
+
+            // Act
+            var result = exception.Message;
+
+            // Assert
+           Assert.That(result, Is.EqualTo("User with this email already exists!"));
+        }
+    }
+}

--- a/SelfGuidedTours.Tests/UnitTests/ExceptionHandlingMiddlewareTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/ExceptionHandlingMiddlewareTests.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using SelfGuidedTours.Api.Middlewares;
+using SelfGuidedTours.Core.CustomExceptions;
+
+namespace SelfGuidedTours.Tests.UnitTests
+{
+    [TestFixture]
+    public class ExceptionHandlingMiddlewareTests
+    {
+        private ILoggerFactory loggerFactory;
+        private ILogger<ExceptionHandlerMiddleware> logger;
+        private DefaultHttpContext context;
+        [SetUp]
+        public void Setup()
+        {
+            context = new DefaultHttpContext();
+            loggerFactory = new LoggerFactory();
+            logger = new Logger<ExceptionHandlerMiddleware>(loggerFactory);
+        }
+        [TearDown]
+        public void TearDown()
+        {
+            loggerFactory.Dispose();
+        }
+
+        [Test]
+        public async Task ExceptionHandlerMiddleware_ShouldReturnBadRequest()
+        {
+            // Arrange
+            RequestDelegate next = (HttpContext context) => throw new ArgumentException();
+            var middleware = new ExceptionHandlerMiddleware(logger, next);
+            context.Response.Body = new MemoryStream();
+            context.Response.StatusCode = 0;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.That(context.Response.StatusCode, Is.EqualTo(400));
+        }
+        [Test]
+        public async Task ExceptionHandlerMiddleware_ShouldReturnUnauthorized()
+        {
+            // Arrange
+            RequestDelegate next = (HttpContext context) => throw new UnauthorizedAccessException();
+            var middleware = new ExceptionHandlerMiddleware(logger, next);
+            context.Response.Body = new MemoryStream();
+            context.Response.StatusCode = 0;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.That(context.Response.StatusCode, Is.EqualTo(401));
+        }
+        [Test]
+        public async Task ExceptionHandlerMiddleware_ShouldReturnNotFound()
+        {
+            // Arrange
+            RequestDelegate next = (HttpContext context) => throw new KeyNotFoundException();
+            var middleware = new ExceptionHandlerMiddleware(logger, next);
+            context.Response.Body = new MemoryStream();
+            context.Response.StatusCode = 0;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.That(context.Response.StatusCode, Is.EqualTo(404));
+        }
+        [Test]
+        public async Task ExceptionHandlerMiddleware_ShouldReturnRequestTimeout()
+        {
+            // Arrange
+            RequestDelegate next = (HttpContext context) => throw new TimeoutException();
+            var middleware = new ExceptionHandlerMiddleware(logger, next);
+            context.Response.Body = new MemoryStream();
+            context.Response.StatusCode = 0;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.That(context.Response.StatusCode, Is.EqualTo(408));
+        }
+        [Test]
+        public async Task ExceptionHandlerMiddleware_ShouldReturnInternalServerError()
+        {
+            // Arrange
+            RequestDelegate next = (HttpContext context) => throw new Exception();
+            var middleware = new ExceptionHandlerMiddleware(logger, next);
+            context.Response.Body = new MemoryStream();
+            context.Response.StatusCode = 0;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.That(context.Response.StatusCode, Is.EqualTo(500));
+        }
+        [Test]
+        public async Task ExceptionHandlerMiddleware_ShouldReturnBadRequestWithErrorMessage()
+        {
+            // Arrange
+            RequestDelegate next = (HttpContext context) => throw new EmailAlreadyInUseException();
+            var middleware = new ExceptionHandlerMiddleware(logger, next);
+            context.Response.Body = new MemoryStream();
+            context.Response.StatusCode = 0;
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.That(context.Response.StatusCode, Is.EqualTo(400));
+            Assert.That(context.Response.Body.Length, Is.GreaterThan(0));
+        }
+    }
+ }


### PR DESCRIPTION
1. Added custom exception to handle Email Already exists on register
2. Changed the logic in ExceptionHandlingMidlleware to handle the new custom error and return resposne "Email":"Email error"
3. Added tests for the new exception.
We are doing this so that the front end validation can work propperly and display the error under the Email input field, it works with keys "Email", "Password" etc
![image](https://github.com/user-attachments/assets/339e30f3-1989-4d11-baa4-b50c8c3098a3)
