### PR TITLE
Feature/vot 159 add customize email templates

### DIFF
--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -184,17 +184,25 @@ namespace SelfGuidedTours.Api.Controllers
         {
             if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(token))
             {
+                logger.LogError("UserId or Token is missing.");
                 return BadRequest("UserId and Token are required.");
             }
+
+            logger.LogInformation($"ConfirmEmail called with userId: {userId}, token: {token}");
 
             var result = await authService.ConfirmEmailAsync(userId, token);
             if (result.Succeeded)
             {
+                logger.LogInformation("Email confirmed successfully.");
                 return Ok("Email confirmed successfully!");
             }
 
-            return BadRequest("Email confirmation failed.");
+            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+            logger.LogError($"Email confirmation failed. Errors: {errors}");
+            return BadRequest(new { message = "Email confirmation failed.", errors });
         }
+
+
 
     }
 }

--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -196,7 +196,7 @@ namespace SelfGuidedTours.Api.Controllers
                 return BadRequest("UserId and Token are required.");
             }
 
-            logger.LogInformation($"ConfirmEmail called with userId: {userId}, token: {token}");
+            logger.LogInformation($"ConfirmEmail called with userId: {userId}, token: {token}");//remove this later to avoid injection attacks
 
             var result = await authService.ConfirmEmailAsync(userId, token);
             if (result.Succeeded)

--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -37,13 +37,14 @@ namespace SelfGuidedTours.Api.Controllers
 
             if (result != null)
             {
-                var confirmationLink = Url.Action("ConfirmEmail", "Auth", new { token = result.EmailConfirmationToken }, Request.Scheme);
+                var confirmationLink = Url.Action("ConfirmEmail", "Auth", new { userId = result.UserId, token = result.EmailConfirmationToken }, Request.Scheme);
                 await emailService.SendEmailConfirmationAsync(result.Email, confirmationLink!);
-                return Ok("Registration successful! Please check your email to confirm your registration.");
+                return Ok(new { message = "Registration successful! Please check your email to confirm your registration.", userId = result.UserId, token = result.EmailConfirmationToken });
             }
 
             return BadRequest("Registration failed.");
         }
+
 
         [HttpPost("login")]
         [ProducesResponseType(typeof(AuthenticateResponse), 200)]
@@ -179,14 +180,21 @@ namespace SelfGuidedTours.Api.Controllers
         [HttpGet("confirm-email")]
         [ProducesResponseType(typeof(string), 200)]
         [ProducesResponseType(typeof(string), 400)]
-        public async Task<IActionResult> ConfirmEmail([FromQuery] string token)
+        public async Task<IActionResult> ConfirmEmail([FromQuery] string userId, [FromQuery] string token)
         {
-            var result = await authService.ConfirmEmailAsync(token);
+            if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(token))
+            {
+                return BadRequest("UserId and Token are required.");
+            }
+
+            var result = await authService.ConfirmEmailAsync(userId, token);
             if (result.Succeeded)
             {
                 return Ok("Email confirmed successfully!");
             }
+
             return BadRequest("Email confirmation failed.");
         }
+
     }
 }

--- a/SelfGuidedTours.Api/Controllers/AuthController.cs
+++ b/SelfGuidedTours.Api/Controllers/AuthController.cs
@@ -146,10 +146,18 @@ namespace SelfGuidedTours.Api.Controllers
             var token = await authService.GeneratePasswordResetTokenAsync(user);
             var resetLink = Url.Action("ResetPassword", "Auth", new { token }, Request.Scheme);
 
-            await emailService.SendPasswordResetEmailAsync(model.Email, resetLink!);
+            var emailDto = new SendEmailDto
+            {
+                To = model.Email,
+                Subject = "Reset Your Password",
+                Body = $"You can reset your password by clicking the link below:\n\n<a href='{resetLink}'>Reset Password</a>"
+            };
+
+            await emailService.SendEmail(emailDto, "html");
 
             return Ok("Password reset link has been sent to your email.");
         }
+
 
         [HttpPost("reset-password")]
         [ProducesResponseType(typeof(string), 200)]

--- a/SelfGuidedTours.Api/EmailTemplates/ConfirmationEmailTemplate.html
+++ b/SelfGuidedTours.Api/EmailTemplates/ConfirmationEmailTemplate.html
@@ -1,0 +1,13 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Confirm your email</title>
+</head>
+<body>
+<h1>Hello, {{UserName}}!</h1>
+<p>Please confirm your email by clicking on the link below:</p>
+<a href="{{ConfirmationLink}}">Confirm Email</a>
+<p>If you did not create an account, please ignore this email.</p>
+</body>
+</html>

--- a/SelfGuidedTours.Api/EmailTemplates/GenericEmailTemplate.html
+++ b/SelfGuidedTours.Api/EmailTemplates/GenericEmailTemplate.html
@@ -7,6 +7,6 @@
 </head>
 <body>
 <h1>{{Subject}}</h1>
-<p>{{Body}}</p>
+<p>{{EmailBody}}</p>
 </body>
 </html>

--- a/SelfGuidedTours.Api/EmailTemplates/GenericEmailTemplate.html
+++ b/SelfGuidedTours.Api/EmailTemplates/GenericEmailTemplate.html
@@ -1,0 +1,12 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{Subject}}</title>
+</head>
+<body>
+<h1>{{Subject}}</h1>
+<p>{{Body}}</p>
+</body>
+</html>

--- a/SelfGuidedTours.Api/EmailTemplates/PasswordResetEmailTemplate.html
+++ b/SelfGuidedTours.Api/EmailTemplates/PasswordResetEmailTemplate.html
@@ -7,9 +7,9 @@
 </head>
 <body>
 <h1>Reset Your Password</h1>
-<p>Hello {{UserName}},</p>
-<p>You can reset your password by clicking on the link below:</p>
-<p><a href="{{ResetLink}}">Reset Password</a></p>
+<p>Hello, {{UserName}}!</p>
+<p>Please reset your password by clicking on the link below:</p>
+<a href="{{ResetLink}}">Reset Password</a>
 <p>If you did not request a password reset, please ignore this email.</p>
 </body>
 </html>

--- a/SelfGuidedTours.Api/EmailTemplates/PasswordResetEmailTemplate.html
+++ b/SelfGuidedTours.Api/EmailTemplates/PasswordResetEmailTemplate.html
@@ -1,0 +1,15 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reset Your Password</title>
+</head>
+<body>
+<h1>Reset Your Password</h1>
+<p>Hello {{UserName}},</p>
+<p>You can reset your password by clicking on the link below:</p>
+<p><a href="{{ResetLink}}">Reset Password</a></p>
+<p>If you did not request a password reset, please ignore this email.</p>
+</body>
+</html>

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -4,16 +4,16 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Azure;
 using Microsoft.IdentityModel.Tokens;
-using SelfGuidedTours.Core.Contracts.BlobStorage;
 using SelfGuidedTours.Core.Contracts;
+using SelfGuidedTours.Core.Contracts.BlobStorage;
 using SelfGuidedTours.Core.Models.ErrorResponse;
 using SelfGuidedTours.Core.Services;
 using SelfGuidedTours.Core.Services.BlobStorage;
 using SelfGuidedTours.Core.Services.TokenGenerators;
 using SelfGuidedTours.Core.Services.TokenValidators;
 using SelfGuidedTours.Infrastructure.Common;
-using SelfGuidedTours.Infrastructure.Data.Models;
 using SelfGuidedTours.Infrastructure.Data;
+using SelfGuidedTours.Infrastructure.Data.Models;
 using System.Text;
 using System.Text.Json.Serialization;
 
@@ -118,7 +118,6 @@ namespace SelfGuidedTours.Api.Extensions
                 .AddEntityFrameworkStores<SelfGuidedToursDbContext>()
                 .AddDefaultTokenProviders();
 
-
             //Password requirements
             services.Configure<IdentityOptions>(options =>
             {
@@ -128,19 +127,20 @@ namespace SelfGuidedTours.Api.Extensions
                 options.Password.RequireUppercase = true;
                 options.Password.RequiredLength = 8;
                 options.Password.RequiredUniqueChars = 1;
+                options.SignIn.RequireConfirmedEmail = true;
             });
 
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>
                 {
                     var key = Environment.GetEnvironmentVariable("ACCESSTOKEN_KEY") ??
-                         throw new ApplicationException("ACCESSTOKEN_KEY is not configured.");
+                             throw new ApplicationException("ACCESSTOKEN_KEY is not configured.");
 
                     var issuer = Environment.GetEnvironmentVariable("ISSUER") ??
-                         throw new ApplicationException("ISSUER is not configured.");
+                             throw new ApplicationException("ISSUER is not configured.");
 
                     var audience = Environment.GetEnvironmentVariable("AUDIENCE") ??
-                         throw new ApplicationException("AUDIENCE is not configured.");
+                             throw new ApplicationException("AUDIENCE is not configured.");
 
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
@@ -156,8 +156,8 @@ namespace SelfGuidedTours.Api.Extensions
                     };
                 });
 
-
             return services;
         }
+
     }
 }

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -28,7 +28,7 @@ namespace SelfGuidedTours.Api.Extensions
              {
                  options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
              })
-             .ConfigureApiBehaviorOptions(options =>  //Customize the response for invalid model state, by overriding the default behavior
+             .ConfigureApiBehaviorOptions(options =>
              {
                  options.InvalidModelStateResponseFactory = ContextBoundObject =>
                  {
@@ -93,7 +93,7 @@ namespace SelfGuidedTours.Api.Extensions
         }
         public static IServiceCollection AddApplicationDbContext(this IServiceCollection services, IConfiguration config)
         {
-            var connectionString = config.GetConnectionString("DefaultConnection"); //Connection string from user secrets
+            var connectionString = config.GetConnectionString("DefaultConnection");
             services.AddDbContext<SelfGuidedToursDbContext>(options =>
             {
                 options.UseSqlServer(connectionString);

--- a/SelfGuidedTours.Api/Program.cs
+++ b/SelfGuidedTours.Api/Program.cs
@@ -53,7 +53,7 @@ app.UseSwaggerUI();
 
 app.UseMiddleware<ExceptionHandlerMiddleware>();
 
-app.UseCors("CorsPolicy");
+app.UseCors("CorsPolicy"); // CorsPolicy
 app.UseHttpsRedirection();
 
 app.UseAuthentication();

--- a/SelfGuidedTours.Api/Program.cs
+++ b/SelfGuidedTours.Api/Program.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+// Program.cs
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi.Models;
 using SelfGuidedTours.Api.Extensions;
@@ -6,7 +6,7 @@ using SelfGuidedTours.Api.Middlewares;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddCustomizedControllers(); // This replaces the AddControllers method, comes from ServiceCollectionExtensions.cs
+builder.Services.AddCustomizedControllers();
 
 builder.Services.AddEndpointsApiExplorer();
 
@@ -47,15 +47,13 @@ builder.Services.AddSwaggerGen(options =>
 var app = builder.Build();
 
 
-//Apply swagger middleware on every enviroment
 app.UseSwagger();
 app.UseSwaggerUI();
 
 
-// Add custom middleware for exception handling to the pipeline
 app.UseMiddleware<ExceptionHandlerMiddleware>();
 
-app.UseCors("CorsPolicy"); // apply CORS policy from ServiceCollectionExtensions.cs
+app.UseCors("CorsPolicy");
 app.UseHttpsRedirection();
 
 app.UseAuthentication();

--- a/SelfGuidedTours.Core/Contracts/IAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IAuthService.cs
@@ -13,10 +13,10 @@ namespace SelfGuidedTours.Core.Contracts
         Task LogoutAsync(string userId);
         Task<AuthenticateResponse> RefreshAsync(RefreshRequestModel model);
         Task<AuthenticateResponse> GoogleSignInAsync(GoogleUserDto googleUser);
-
         Task<ApiResponse> ChangePasswordAsync(ChangePasswordModel model);
         Task<string> GeneratePasswordResetTokenAsync(ApplicationUser user);
         Task<IdentityResult> ResetPasswordAsync(string email, string token, string newPassword);
         Task<ApplicationUser?> GetByEmailAsync(string email);
+        Task<IdentityResult> ConfirmEmailAsync(string token); // Добавен метод
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IAuthService.cs
@@ -17,6 +17,6 @@ namespace SelfGuidedTours.Core.Contracts
         Task<string> GeneratePasswordResetTokenAsync(ApplicationUser user);
         Task<IdentityResult> ResetPasswordAsync(string email, string token, string newPassword);
         Task<ApplicationUser?> GetByEmailAsync(string email);
-        Task<IdentityResult> ConfirmEmailAsync(string token); // Добавен метод
+        Task<IdentityResult> ConfirmEmailAsync(string userId, string token); // Добавен метод
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IAuthService.cs
+++ b/SelfGuidedTours.Core/Contracts/IAuthService.cs
@@ -17,6 +17,6 @@ namespace SelfGuidedTours.Core.Contracts
         Task<string> GeneratePasswordResetTokenAsync(ApplicationUser user);
         Task<IdentityResult> ResetPasswordAsync(string email, string token, string newPassword);
         Task<ApplicationUser?> GetByEmailAsync(string email);
-        Task<IdentityResult> ConfirmEmailAsync(string userId, string token); // Добавен метод
+        Task<IdentityResult> ConfirmEmailAsync(string userId, string token);
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IEmailService.cs
+++ b/SelfGuidedTours.Core/Contracts/IEmailService.cs
@@ -6,5 +6,6 @@ namespace SelfGuidedTours.Core.Contracts
     {
         Task SendEmail(SendEmailDto sendEmailRequest, string emailBodyFormat);
         Task SendPasswordResetEmailAsync(string email, string resetLink);
+        Task SendEmailConfirmationAsync(string email, string confirmationLink); // Added method
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IEmailService.cs
+++ b/SelfGuidedTours.Core/Contracts/IEmailService.cs
@@ -6,6 +6,6 @@ namespace SelfGuidedTours.Core.Contracts
     {
         Task SendEmail(SendEmailDto sendEmailRequest, string emailBodyFormat);
         Task SendPasswordResetEmailAsync(string email, string resetLink);
-        Task SendEmailConfirmationAsync(string email, string confirmationLink); // Added method
+        Task SendEmailConfirmationAsync(string email, string confirmationLink);
     }
 }

--- a/SelfGuidedTours.Core/Models/Auth/AuthenticateResponse.cs
+++ b/SelfGuidedTours.Core/Models/Auth/AuthenticateResponse.cs
@@ -2,9 +2,12 @@
 {
     public class AuthenticateResponse
     {
-        public string AccessToken { get; set; } = string.Empty;
-        public string RefreshToken { get; set; } = string.Empty;
-        public string ResponseMessage { get; set; } = null!;
+        public string AccessToken { get; set; }
+        public string RefreshToken { get; set; }
+        public string ResponseMessage { get; set; }
         public long AccessTokenExpiration { get; set; }
+        public string Email { get; set; } // Добавено свойство
+        public string EmailConfirmationToken { get; set; } // Добавено свойство
     }
+
 }

--- a/SelfGuidedTours.Core/Models/Auth/AuthenticateResponse.cs
+++ b/SelfGuidedTours.Core/Models/Auth/AuthenticateResponse.cs
@@ -6,8 +6,9 @@
         public string RefreshToken { get; set; }
         public string ResponseMessage { get; set; }
         public long AccessTokenExpiration { get; set; }
-        public string Email { get; set; } // Добавено свойство
-        public string EmailConfirmationToken { get; set; } // Добавено свойство
+        public string Email { get; set; }
+        public string EmailConfirmationToken { get; set; }
+        public string UserId { get; set; }
     }
 
 }

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -310,17 +310,17 @@ namespace SelfGuidedTours.Core.Services
             return role.Name;
         }
 
-        public async Task<IdentityResult> ConfirmEmailAsync(string token)
+        public async Task<IdentityResult> ConfirmEmailAsync(string userId, string token)
         {
-            var userId = userManager?.Options?.Tokens?.EmailConfirmationTokenProvider ?? throw new InvalidOperationException("Token provider not configured.");
             var user = await userManager.FindByIdAsync(userId);
             if (user == null)
             {
-                return IdentityResult.Failed(new IdentityError { Description = "Invalid token." });
+                return IdentityResult.Failed(new IdentityError { Description = "Invalid user ID." });
             }
 
             var result = await userManager.ConfirmEmailAsync(user, token);
             return result;
         }
+
     }
 }

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -312,15 +312,24 @@ namespace SelfGuidedTours.Core.Services
 
         public async Task<IdentityResult> ConfirmEmailAsync(string userId, string token)
         {
+            // ???????? ?? ???????? ?????????
+            logger.LogInformation($"ConfirmEmailAsync called with userId: {userId}, token: {token}");
+
             var user = await userManager.FindByIdAsync(userId);
             if (user == null)
             {
+                logger.LogError("Invalid user ID.");
                 return IdentityResult.Failed(new IdentityError { Description = "Invalid user ID." });
             }
 
             var result = await userManager.ConfirmEmailAsync(user, token);
+            if (!result.Succeeded)
+            {
+                var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+                logger.LogError($"Email confirmation failed for user: {user.Email}. Errors: {errors}");
+            }
+
             return result;
         }
-
     }
 }

--- a/SelfGuidedTours.Core/Services/AuthService.cs
+++ b/SelfGuidedTours.Core/Services/AuthService.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.CustomExceptions;
 using SelfGuidedTours.Core.Models;
 using SelfGuidedTours.Core.Models.Auth;
@@ -9,12 +10,8 @@ using SelfGuidedTours.Core.Services.TokenGenerators;
 using SelfGuidedTours.Core.Services.TokenValidators;
 using SelfGuidedTours.Infrastructure.Common;
 using SelfGuidedTours.Infrastructure.Data.Models;
-using System.Net;
-using SelfGuidedTours.Core.Contracts;
-using System;
 using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Net;
 
 namespace SelfGuidedTours.Core.Services
 {
@@ -25,8 +22,8 @@ namespace SelfGuidedTours.Core.Services
         private readonly RefreshTokenGenerator refreshTokenGenerator;
         private readonly RefreshTokenValidator refreshTokenValidator;
         private readonly IRefreshTokenService refreshTokenService;
-        private readonly IProfileService profileService;  
-        private readonly UserManager<ApplicationUser>? userManager;
+        private readonly IProfileService profileService;
+        private readonly UserManager<ApplicationUser> userManager;
         private readonly ILogger<AuthService> logger;
 
         public AuthService(
@@ -35,8 +32,8 @@ namespace SelfGuidedTours.Core.Services
             RefreshTokenGenerator refreshTokenGenerator,
             RefreshTokenValidator refreshTokenValidator,
             IRefreshTokenService refreshTokenService,
-            IProfileService profileService,  
-            UserManager<ApplicationUser>? userManager,
+            IProfileService profileService,
+            UserManager<ApplicationUser> userManager,
             ILogger<AuthService> logger
         )
         {
@@ -45,7 +42,7 @@ namespace SelfGuidedTours.Core.Services
             this.refreshTokenGenerator = refreshTokenGenerator;
             this.refreshTokenValidator = refreshTokenValidator;
             this.refreshTokenService = refreshTokenService;
-            this.profileService = profileService;  
+            this.profileService = profileService;
             this.userManager = userManager;
             this.logger = logger;
         }
@@ -76,7 +73,7 @@ namespace SelfGuidedTours.Core.Services
         private async Task<AuthenticateResponse> AuthenticateAsync(ApplicationUser user, string responseMessage)
         {
             var role = await GetUserRoleAsync(user);
-            var accessToken = accessTokenGenerator.GenerateToken(user,role);
+            var accessToken = accessTokenGenerator.GenerateToken(user, role);
             var refreshToken = refreshTokenGenerator.GenerateToken();
 
             RefreshToken refreshTokenDTO = new RefreshToken()
@@ -92,7 +89,8 @@ namespace SelfGuidedTours.Core.Services
                 AccessToken = accessToken,
                 RefreshToken = refreshToken,
                 ResponseMessage = responseMessage,
-                AccessTokenExpiration = GetTokenExpirationTime(accessToken)
+                AccessTokenExpiration = GetTokenExpirationTime(accessToken),
+                Email = user.Email,
             };
         }
 
@@ -135,7 +133,11 @@ namespace SelfGuidedTours.Core.Services
 
             await profileService.CreateProfileAsync(userProfile);
 
-            return await AuthenticateAsync(user, "User registered successfully!");
+            var emailConfirmationToken = await userManager.GenerateEmailConfirmationTokenAsync(user);
+
+            var response = await AuthenticateAsync(user, "User registered successfully!");
+            response.EmailConfirmationToken = emailConfirmationToken;
+            return response;
         }
 
         public async Task<AuthenticateResponse> LoginAsync(LoginInputModel model)
@@ -234,7 +236,7 @@ namespace SelfGuidedTours.Core.Services
             }
 
             var user = await GetByIdAsync(model.UserId);
-            
+
             if (user is null) throw new UnauthorizedAccessException("User not found");
 
             if (user.PasswordHash is null) throw new UnauthorizedAccessException("User has no assigned password!");
@@ -244,10 +246,9 @@ namespace SelfGuidedTours.Core.Services
             var result = hasher.VerifyHashedPassword(user, user.PasswordHash, model.CurrentPassword);
 
             if (result != PasswordVerificationResult.Success) throw new UnauthorizedAccessException("Invalid password");
-            
+
             user.PasswordHash = hasher.HashPassword(user, model.NewPassword);
 
-            //await repository.UpdateAsync(user);
             await repository.SaveChangesAsync();
 
             var response = new ApiResponse
@@ -260,13 +261,13 @@ namespace SelfGuidedTours.Core.Services
 
         public async Task<string> GeneratePasswordResetTokenAsync(ApplicationUser user)
         {
-            var token = await userManager!.GeneratePasswordResetTokenAsync(user);
+            var token = await userManager.GeneratePasswordResetTokenAsync(user);
             return token;
         }
-        
+
         public async Task<IdentityResult> ResetPasswordAsync(string email, string token, string newPassword)
         {
-            var user = await userManager!.FindByEmailAsync(email);
+            var user = await userManager.FindByEmailAsync(email);
             if (user == null)
             {
                 return IdentityResult.Failed(new IdentityError { Description = "Invalid email." });
@@ -290,23 +291,36 @@ namespace SelfGuidedTours.Core.Services
             }
 
             logger.LogInformation($"Password reset succeeded for user: {user.Email}");
-            
+
             return result;
         }
-        private async Task<string>GetUserRoleAsync(ApplicationUser user)
+
+        private async Task<string> GetUserRoleAsync(ApplicationUser user)
         {
-            //Get UserRole
             var userRole = await repository.AllReadOnly<IdentityUserRole<string>>()
                 .FirstOrDefaultAsync(ur => ur.UserId == user.Id)
                 ?? throw new UnauthorizedAccessException("User has no assigned role!");
-            //Get Role
+
             var role = await repository.AllReadOnly<IdentityRole>()
                 .FirstOrDefaultAsync(r => r.Id == userRole.RoleId);
 
-            if (role is null || role.Name is null) 
+            if (role is null || role.Name is null)
                 throw new UnauthorizedAccessException("User has no assigned role!");
 
             return role.Name;
+        }
+
+        public async Task<IdentityResult> ConfirmEmailAsync(string token)
+        {
+            var userId = userManager?.Options?.Tokens?.EmailConfirmationTokenProvider ?? throw new InvalidOperationException("Token provider not configured.");
+            var user = await userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                return IdentityResult.Failed(new IdentityError { Description = "Invalid token." });
+            }
+
+            var result = await userManager.ConfirmEmailAsync(user, token);
+            return result;
         }
     }
 }

--- a/SelfGuidedTours.Core/Services/EmailService.cs
+++ b/SelfGuidedTours.Core/Services/EmailService.cs
@@ -31,7 +31,7 @@ namespace SelfGuidedTours.Core.Services
             };
 
             using var smtp = new SmtpClient();
-            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; // Игнориране на сертификатните грешки (само за тестване)
+            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
             smtp.Connect(emailHost, int.Parse(emailPort), SecureSocketOptions.SslOnConnect);
             smtp.Authenticate(emailSender, emailPassword);
             await smtp.SendAsync(email);
@@ -50,7 +50,7 @@ namespace SelfGuidedTours.Core.Services
             };
 
             using var smtp = new SmtpClient();
-            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; // Игнориране на сертификатните грешки (само за тестване)
+            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
             smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
             smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
             await smtp.SendAsync(mailMessage);
@@ -69,7 +69,7 @@ namespace SelfGuidedTours.Core.Services
             };
 
             using var smtp = new SmtpClient();
-            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; // Игнориране на сертификатните грешки (само за тестване)
+            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
             smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
             smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
             await smtp.SendAsync(mailMessage);

--- a/SelfGuidedTours.Core/Services/EmailService.cs
+++ b/SelfGuidedTours.Core/Services/EmailService.cs
@@ -1,5 +1,4 @@
-﻿
-using MailKit.Net.Smtp;
+﻿using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
 using MimeKit.Text;
@@ -32,6 +31,7 @@ namespace SelfGuidedTours.Core.Services
             };
 
             using var smtp = new SmtpClient();
+            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; // Игнориране на сертификатните грешки (само за тестване)
             smtp.Connect(emailHost, int.Parse(emailPort), SecureSocketOptions.SslOnConnect);
             smtp.Authenticate(emailSender, emailPassword);
             await smtp.SendAsync(email);
@@ -50,12 +50,30 @@ namespace SelfGuidedTours.Core.Services
             };
 
             using var smtp = new SmtpClient();
-           // smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; // Disable certificate checking
+            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; // Игнориране на сертификатните грешки (само за тестване)
             smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
             smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
             await smtp.SendAsync(mailMessage);
             smtp.Disconnect(true);
         }
 
+        public async Task SendEmailConfirmationAsync(string email, string confirmationLink)
+        {
+            var mailMessage = new MimeMessage();
+            mailMessage.From.Add(MailboxAddress.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME")));
+            mailMessage.To.Add(MailboxAddress.Parse(email));
+            mailMessage.Subject = "Confirm Your Email";
+            mailMessage.Body = new TextPart(TextFormat.Html)
+            {
+                Text = $"Please confirm your email by clicking on the link: <a href='{confirmationLink}'>Confirm Email</a>"
+            };
+
+            using var smtp = new SmtpClient();
+            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; // Игнориране на сертификатните грешки (само за тестване)
+            smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
+            smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
+            await smtp.SendAsync(mailMessage);
+            smtp.Disconnect(true);
+        }
     }
 }

--- a/SelfGuidedTours.Core/Services/EmailService.cs
+++ b/SelfGuidedTours.Core/Services/EmailService.cs
@@ -6,87 +6,89 @@ using MimeKit.Text;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models;
 
-namespace SelfGuidedTours.Core.Services
+public class EmailService : IEmailService
 {
-    public class EmailService : IEmailService
+    private readonly IConfiguration _configuration;
+
+    public EmailService(IConfiguration configuration)
     {
-        private readonly IConfiguration _configuration;
+        _configuration = configuration;
+    }
 
-        public EmailService(IConfiguration configuration)
+    public async Task SendEmail(SendEmailDto sendEmailRequest, string emailBodyFormat = "plain")
+    {
+        var templatePath = _configuration["EmailTemplates:GenericEmailTemplate"];
+        var emailBody = await File.ReadAllTextAsync(templatePath);
+        emailBody = emailBody.Replace("{{Subject}}", sendEmailRequest.Subject);
+        emailBody = emailBody.Replace("{{Body}}", sendEmailRequest.Body);
+
+        var emailSender = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME") ?? throw new ApplicationException("Email sender is not configured.");
+        var emailHost = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST") ?? throw new ApplicationException("Email host is not configured.");
+        var emailPort = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT") ?? throw new ApplicationException("Email port is not configured.");
+        var emailPassword = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD") ?? throw new ApplicationException("Email password is not configured.");
+
+        var email = new MimeMessage();
+        email.From.Add(MailboxAddress.Parse(emailSender));
+        email.To.Add(MailboxAddress.Parse(sendEmailRequest.To));
+        email.Subject = sendEmailRequest.Subject;
+        email.Body = new TextPart(TextFormat.Html)
         {
-            _configuration = configuration;
-        }
+            Text = emailBody
+        };
 
-        public async Task SendEmail(SendEmailDto sendEmailRequest, string emailBodyFormat = "plain")
+        using var smtp = new SmtpClient();
+        smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
+        smtp.Connect(emailHost, int.Parse(emailPort), SecureSocketOptions.SslOnConnect);
+        smtp.Authenticate(emailSender, emailPassword);
+        await smtp.SendAsync(email);
+        smtp.Disconnect(true);
+    }
+
+    public async Task SendPasswordResetEmailAsync(string email, string resetLink)
+    {
+        var templatePath = _configuration["EmailTemplates:PasswordResetEmailTemplate"];
+        var emailBody = await File.ReadAllTextAsync(templatePath);
+        emailBody = emailBody.Replace("{{UserName}}", email);
+        emailBody = emailBody.Replace("{{ResetLink}}", resetLink);
+
+        var mailMessage = new MimeMessage();
+        mailMessage.From.Add(MailboxAddress.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME")));
+        mailMessage.To.Add(MailboxAddress.Parse(email));
+        mailMessage.Subject = "Reset Your Password";
+        mailMessage.Body = new TextPart(TextFormat.Html)
         {
-            if (!Enum.TryParse(emailBodyFormat, true, out TextFormat _))
-            {
-                throw new ArgumentException("Invalid email body format, possible formats \"html\", \"plain\", \"rtf\", \"enriched\"", nameof(emailBodyFormat));
-            }
+            Text = emailBody
+        };
 
-            var emailSender = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME") ?? throw new ApplicationException("Email sender is not configured.");
-            var emailHost = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST") ?? throw new ApplicationException("Email host is not configured.");
-            var emailPort = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT") ?? throw new ApplicationException("Email port is not configured.");
-            var emailPassword = Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD") ?? throw new ApplicationException("Email password is not configured.");
+        using var smtp = new SmtpClient();
+        smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
+        smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
+        smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
+        await smtp.SendAsync(mailMessage);
+        smtp.Disconnect(true);
+    }
 
-            var email = new MimeMessage();
-            email.From.Add(MailboxAddress.Parse(emailSender));
-            email.To.Add(MailboxAddress.Parse(sendEmailRequest.To));
-            email.Subject = sendEmailRequest.Subject;
-            email.Body = new TextPart(emailBodyFormat)
-            {
-                Text = sendEmailRequest.Body
-            };
+    public async Task SendEmailConfirmationAsync(string email, string confirmationLink)
+    {
+        var templatePath = _configuration["EmailTemplates:ConfirmationEmailTemplate"];
+        var emailBody = await File.ReadAllTextAsync(templatePath);
+        emailBody = emailBody.Replace("{{UserName}}", email);
+        emailBody = emailBody.Replace("{{ConfirmationLink}}", confirmationLink);
 
-            using var smtp = new SmtpClient();
-            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
-            smtp.Connect(emailHost, int.Parse(emailPort), SecureSocketOptions.SslOnConnect);
-            smtp.Authenticate(emailSender, emailPassword);
-            await smtp.SendAsync(email);
-            smtp.Disconnect(true);
-        }
-
-        public async Task SendPasswordResetEmailAsync(string email, string resetLink)
+        var mailMessage = new MimeMessage();
+        mailMessage.From.Add(MailboxAddress.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME")));
+        mailMessage.To.Add(MailboxAddress.Parse(email));
+        mailMessage.Subject = "Confirm Your Email";
+        mailMessage.Body = new TextPart(TextFormat.Html)
         {
-            var mailMessage = new MimeMessage();
-            mailMessage.From.Add(MailboxAddress.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME")));
-            mailMessage.To.Add(MailboxAddress.Parse(email));
-            mailMessage.Subject = "Reset Your Password";
-            mailMessage.Body = new TextPart(TextFormat.Html)
-            {
-                Text = $"Please reset your password by clicking on the link: <a href='{resetLink}'>Reset Password</a>"
-            };
+            Text = emailBody
+        };
 
-            using var smtp = new SmtpClient();
-            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
-            smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
-            smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
-            await smtp.SendAsync(mailMessage);
-            smtp.Disconnect(true);
-        }
-
-        public async Task SendEmailConfirmationAsync(string email, string confirmationLink)
-        {
-            var templatePath = _configuration["EmailTemplates:ConfirmationEmailTemplate"];
-            var emailBody = await File.ReadAllTextAsync(templatePath);
-            emailBody = emailBody.Replace("{{UserName}}", email);
-            emailBody = emailBody.Replace("{{ConfirmationLink}}", confirmationLink);
-
-            var mailMessage = new MimeMessage();
-            mailMessage.From.Add(MailboxAddress.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME")));
-            mailMessage.To.Add(MailboxAddress.Parse(email));
-            mailMessage.Subject = "Confirm Your Email";
-            mailMessage.Body = new TextPart(TextFormat.Html)
-            {
-                Text = emailBody
-            };
-
-            using var smtp = new SmtpClient();
-            smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
-            smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
-            smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
-            await smtp.SendAsync(mailMessage);
-            smtp.Disconnect(true);
-        }
+        using var smtp = new SmtpClient();
+        smtp.ServerCertificateValidationCallback = (s, c, h, e) => true; //Ignore certificate errors (for testing only)
+        smtp.Connect(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_HOST"), int.Parse(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PORT")!), SecureSocketOptions.SslOnConnect);
+        smtp.Authenticate(Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME"), Environment.GetEnvironmentVariable("ASPNETCORE_SMTP_PASSWORD"));
+        await smtp.SendAsync(mailMessage);
+        smtp.Disconnect(true);
     }
 }


### PR DESCRIPTION
I added custom email template for registration,reset password and generic email. You can modify the html files in EmailTemplates folder as you wish.

Add this in: secrets.json:

"EmailTemplates": {
  "ConfirmationEmailTemplate": "EmailTemplates/ConfirmationEmailTemplate.html",
  "PasswordResetEmailTemplate": "EmailTemplates/PasswordResetEmailTemplate.html",
  "GenericEmailTemplate": "EmailTemplates/GenericEmailTemplate.html"
}
 
 
![chrome_5DvIykd2qt](https://github.com/user-attachments/assets/553ad444-5b6e-4e90-a913-acf9b4882bef)
