### PR TITLE
Change Payment Controller

### DIFF
--- a/SelfGuidedTours.Api/Controllers/PaymentController.cs
+++ b/SelfGuidedTours.Api/Controllers/PaymentController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models;
+using System.Security.Claims;
 
 namespace SelfGuidedTours.Api.Controllers
 {
@@ -15,9 +16,12 @@ namespace SelfGuidedTours.Api.Controllers
             _paymentService = paymentService;
         }
 
-        [HttpPost("{userId}")]
-        public async Task<ActionResult<ApiResponse>> MakePayment(string userId, [FromBody] PaymentRequest paymentRequest)
+        [HttpPost("{tourId}")]
+        public async Task<ActionResult<ApiResponse>> MakePayment([FromRoute] PaymentRequest paymentRequest)
         {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                             ?? throw new UnauthorizedAccessException();
+
             var response = await _paymentService.MakePaymentAsync(userId, paymentRequest);
             return StatusCode((int)response.StatusCode, response);
         }

--- a/SelfGuidedTours.Api/Controllers/PaymentController.cs
+++ b/SelfGuidedTours.Api/Controllers/PaymentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models;
 using System.Security.Claims;
@@ -7,6 +8,7 @@ namespace SelfGuidedTours.Api.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize]
     public class PaymentController : ControllerBase
     {
         private readonly IPaymentService _paymentService;
@@ -16,13 +18,15 @@ namespace SelfGuidedTours.Api.Controllers
             _paymentService = paymentService;
         }
 
-        [HttpPost("{tourId}")]
-        public async Task<ActionResult<ApiResponse>> MakePayment([FromRoute] PaymentRequest paymentRequest)
+        [HttpPost("{tourId:int}")]
+        public async Task<ActionResult<ApiResponse>> MakePayment([FromRoute] int tourId)
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)
-                             ?? throw new UnauthorizedAccessException();
+            var userId = User.Claims.First().Value
+                ?? throw new ArgumentNullException("User not found!");
 
-            var response = await _paymentService.MakePaymentAsync(userId, paymentRequest);
+
+            var response = await _paymentService.MakePaymentAsync(userId, tourId);
+
             return StatusCode((int)response.StatusCode, response);
         }
     }

--- a/SelfGuidedTours.Api/Controllers/PaymentController.cs
+++ b/SelfGuidedTours.Api/Controllers/PaymentController.cs
@@ -2,6 +2,8 @@
 using Microsoft.AspNetCore.Mvc;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models;
+using SelfGuidedTours.Core.Models.Dto;
+using Stripe;
 using System.Security.Claims;
 
 namespace SelfGuidedTours.Api.Controllers
@@ -12,10 +14,12 @@ namespace SelfGuidedTours.Api.Controllers
     public class PaymentController : ControllerBase
     {
         private readonly IPaymentService _paymentService;
+        private readonly ILogger<PaymentController> logger;
 
-        public PaymentController(IPaymentService paymentService)
+        public PaymentController(IPaymentService paymentService, ILogger<PaymentController> logger)
         {
             _paymentService = paymentService;
+            this.logger = logger;
         }
 
         [HttpPost("{tourId:int}")]
@@ -28,6 +32,41 @@ namespace SelfGuidedTours.Api.Controllers
             var response = await _paymentService.MakePaymentAsync(userId, tourId);
 
             return StatusCode((int)response.StatusCode, response);
+        }
+
+        // This gets called by the Stripe API when a payment is successful
+        [HttpPost("webhook")]
+        [AllowAnonymous]
+        public async Task<IActionResult> FinilizePaymentWebHook()
+        {
+            var endpointSecret = Environment.GetEnvironmentVariable("STRIPE_ENDPOINT_SECRET")
+                ?? throw new ArgumentNullException("Stripe endpoint secret variable not setuped!");
+
+            var json = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+            
+                var stripeEvent = EventUtility.ConstructEvent(json,
+                    Request.Headers["Stripe-Signature"], endpointSecret);
+
+                // Handle the event
+                if (stripeEvent.Type == Events.PaymentIntentSucceeded)
+                {
+                    var paymentIntent = stripeEvent.Data.Object as PaymentIntent;
+
+                    if (paymentIntent == null)
+                    {
+                        return BadRequest();
+                    }
+                    // Fulfill the purchase...
+                    await _paymentService.FinalizePaymentAsync(paymentIntent.Id);
+                }
+                else
+                {
+                    logger.LogWarning("Unhandled event type: {0}", stripeEvent.Type);
+                }
+
+                return Ok();
+            
+            
         }
     }
 }

--- a/SelfGuidedTours.Api/Controllers/PaymentController.cs
+++ b/SelfGuidedTours.Api/Controllers/PaymentController.cs
@@ -65,8 +65,17 @@ namespace SelfGuidedTours.Api.Controllers
                 }
 
                 return Ok();
+        }
             
-            
+        [HttpPost("free/{tourId:int}")]
+        public async Task<ActionResult<ApiResponse>> AddFreeTour([FromRoute] int tourId)
+        {
+            var userId = User.Claims.First().Value
+                ?? throw new ArgumentNullException("User not found!");
+
+            var response = await _paymentService.AddFreeTour(userId, tourId);
+
+            return StatusCode((int)response.StatusCode, response);
         }
     }
 }

--- a/SelfGuidedTours.Api/Controllers/ReviewController.cs
+++ b/SelfGuidedTours.Api/Controllers/ReviewController.cs
@@ -17,13 +17,11 @@ namespace SelfGuidedTours.Api.Controllers
     public class ReviewController : ControllerBase
     {
         private readonly IReviewService _reviewService;
-        private readonly UserManager<ApplicationUser> _userManager;
         private readonly ApiResponse _response;
 
-        public ReviewController(IReviewService reviewService, UserManager<ApplicationUser> userManager)
+        public ReviewController(IReviewService reviewService)
         {
             _reviewService = reviewService;
-            _userManager = userManager;
             _response = new ApiResponse();
         }
 

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -90,9 +90,10 @@ namespace SelfGuidedTours.Api.Extensions
                     .AllowAnyHeader();
                 });
             });
+            // Setup Stripe
+            var stripeKey = config.GetValue<string>("StripeSettings:SecretKey")
+                        ?? throw new ApplicationException("Stripe ENV variables are not configured.");
 
-            StripeConfiguration.ApiKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY") 
-                    ?? throw new ApplicationException("Stripe ENV variables are not configured.");
 
             return services;
         }

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -72,7 +72,7 @@ namespace SelfGuidedTours.Api.Extensions
             services.AddScoped<IPaymentService, PaymentService>();
             services.AddScoped<IBlobService, BlobService>();
             services.AddScoped<IAdminService, AdminService>();
-            services.AddScoped<IReviewService, ReviewService>(); // Add this line
+            services.AddScoped<IReviewService, Core.Services.ReviewService>(); // Add this line
 
             // Token generators
             services.AddScoped<AccessTokenGenerator>();

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -94,7 +94,18 @@ namespace SelfGuidedTours.Api.Extensions
             var stripeKey = config.GetValue<string>("StripeSettings:SecretKey")
                         ?? throw new ApplicationException("Stripe ENV variables are not configured.");
             services.AddSingleton<IStripeClient>(new StripeClient(stripeKey));
-
+            // Add Stripe customer service in DI container
+            services.AddScoped<CustomerService>(provider =>
+            {
+                var stripeClient = provider.GetRequiredService<IStripeClient>();
+                return new CustomerService(stripeClient);
+            });
+            // Add Stripe payment intent service in DI container
+            services.AddScoped<PaymentIntentService>(provider =>
+            {
+                var stripeClient = provider.GetRequiredService<IStripeClient>();
+                return new PaymentIntentService(stripeClient);
+            });
             return services;
         }
 

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -94,18 +94,21 @@ namespace SelfGuidedTours.Api.Extensions
             var stripeKey = config.GetValue<string>("StripeSettings:SecretKey")
                         ?? throw new ApplicationException("Stripe ENV variables are not configured.");
             services.AddSingleton<IStripeClient>(new StripeClient(stripeKey));
+
             // Add Stripe customer service in DI container
-            services.AddScoped<CustomerService>(provider =>
+            services.AddScoped(provider =>
             {
                 var stripeClient = provider.GetRequiredService<IStripeClient>();
                 return new CustomerService(stripeClient);
             });
+
             // Add Stripe payment intent service in DI container
-            services.AddScoped<PaymentIntentService>(provider =>
+            services.AddScoped(provider =>
             {
                 var stripeClient = provider.GetRequiredService<IStripeClient>();
                 return new PaymentIntentService(stripeClient);
             });
+
             return services;
         }
 

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using SelfGuidedTours.Infrastructure.Data;
 using SelfGuidedTours.Infrastructure.Data.Models;
 using System.Text;
 using System.Text.Json.Serialization;
+using Stripe;
 
 namespace SelfGuidedTours.Api.Extensions
 {
@@ -89,6 +90,9 @@ namespace SelfGuidedTours.Api.Extensions
                     .AllowAnyHeader();
                 });
             });
+
+            StripeConfiguration.ApiKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY") 
+                    ?? throw new ApplicationException("Stripe ENV variables are not configured.");
 
             return services;
         }

--- a/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SelfGuidedTours.Api/Extensions/ServiceCollectionExtensions.cs
@@ -93,7 +93,7 @@ namespace SelfGuidedTours.Api.Extensions
             // Setup Stripe
             var stripeKey = config.GetValue<string>("StripeSettings:SecretKey")
                         ?? throw new ApplicationException("Stripe ENV variables are not configured.");
-
+            services.AddSingleton<IStripeClient>(new StripeClient(stripeKey));
 
             return services;
         }

--- a/SelfGuidedTours.Api/Properties/launchSettings.json
+++ b/SelfGuidedTours.Api/Properties/launchSettings.json
@@ -38,7 +38,8 @@
         "ISSUER": "https://localhost:7038",
         "AUDIENCE": "https://localhost:7038",
         "CONTAINER_NAME": "landmark-resources",
-        "STRIPE_SECRET_KEY": "sk_test_51PkIqVRqAW3M0tQmfAmfSVKhwt5rUEqPcSEnWr4VyyBpCNvXY2ffxvRGt3hBFoq8s6q9EA3Qj93fzdPgb8q1PziU00qxffv9Hj"
+        "STRIPE_SECRET_KEY": "sk_test_51PkIqVRqAW3M0tQmfAmfSVKhwt5rUEqPcSEnWr4VyyBpCNvXY2ffxvRGt3hBFoq8s6q9EA3Qj93fzdPgb8q1PziU00qxffv9Hj",
+        "STRIPE_ENDPOINT_SECRET": "whsec_5ba0ef09a5db82d10ae6ff74f43cbb66343bc88188faf5143e29239c64d8c805"
       }
     },
     "IIS Express": {

--- a/SelfGuidedTours.Api/Properties/launchSettings.json
+++ b/SelfGuidedTours.Api/Properties/launchSettings.json
@@ -37,7 +37,8 @@
         "ACCESSTOKEN_EXPIRATIONMINUTES": "50",
         "ISSUER": "https://localhost:7038",
         "AUDIENCE": "https://localhost:7038",
-        "CONTAINER_NAME": "landmark-resources"
+        "CONTAINER_NAME": "landmark-resources",
+        "STRIPE_SECRET_KEY": "sk_test_51PkIqVRqAW3M0tQmfAmfSVKhwt5rUEqPcSEnWr4VyyBpCNvXY2ffxvRGt3hBFoq8s6q9EA3Qj93fzdPgb8q1PziU00qxffv9Hj"
       }
     },
     "IIS Express": {

--- a/SelfGuidedTours.Common/Constants/PaymentConstants.cs
+++ b/SelfGuidedTours.Common/Constants/PaymentConstants.cs
@@ -21,5 +21,7 @@ namespace SelfGuidedTours.Common.Constants
         public const string TourPriceNotSetMessage = "Tour price is not set!";
 
         public const string SuccesfullPaymentMessage = "Payment successful!";
+
+        public const string PaymentNotFoundMessage = "Payment not found!";
     }
 }

--- a/SelfGuidedTours.Common/Constants/PaymentConstants.cs
+++ b/SelfGuidedTours.Common/Constants/PaymentConstants.cs
@@ -23,5 +23,9 @@ namespace SelfGuidedTours.Common.Constants
         public const string SuccesfullPaymentMessage = "Payment successful!";
 
         public const string PaymentNotFoundMessage = "Payment not found!";
+
+        public const string TourNotFreeMessage = "Tour is not free!";
+
+        public const string FreeTourAddedMessage = "Tour successfully added to collection!";
     }
 }

--- a/SelfGuidedTours.Common/Constants/PaymentConstants.cs
+++ b/SelfGuidedTours.Common/Constants/PaymentConstants.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SelfGuidedTours.Common.Constants
+{
+    public static class PaymentConstants
+    {
+        public const string UserNotFoundMessage = "User not found!";
+
+        public const string CustomerDescription = "Customer for Jauntster"; //TODO: Figure out if this is meaningfull and if it should be a changed
+
+        public const string InvalidPaymentRequestMessage = "Invalid payment request!";
+
+        public const string TourNotFoundMessage = "Tour not found!";
+
+        public const string TourAlreadyPurchasedMessage = "Tour already purchased!";
+
+        public const string TourPriceNotSetMessage = "Tour price is not set!";
+
+        public const string SuccesfullPaymentMessage = "Payment successful!";
+    }
+}

--- a/SelfGuidedTours.Common/MessageConstants/LoggerMessages.cs
+++ b/SelfGuidedTours.Common/MessageConstants/LoggerMessages.cs
@@ -8,5 +8,6 @@
         public const string PaymentCreatetSuccessfully = "Payment created with id: {0}";
         public const string UserTourCreatedSuccessfully = "UserTour created with id: {0}";
         public const string PaymentIntentCreatedSuccessfully = "PaymentIntent created with id: {0}";
+        public const string PyamentMarkedAsSucceeded = "Payment marked as succeeded with id: {0}";
     }
 }

--- a/SelfGuidedTours.Common/MessageConstants/LoggerMessages.cs
+++ b/SelfGuidedTours.Common/MessageConstants/LoggerMessages.cs
@@ -2,12 +2,12 @@
 {
     public static class LoggerMessages
     {
-        public const string InformationMessageForAllSucessfullyReturnedToursForAdmin = "Sucessfully returned all tours with status {0}!";
+        public const string InformationMessageForAllSuccessfullyReturnedToursForAdmin = "Sucessfully returned all tours with status {0}!";
         public const string WarningMessageForNotFoundedToursForAdmin = "No tours found!";
         public const string StripeCustomerCreatedSuccessfully = "Customer created with id: {0}";
-        public const string PaymentCreatetSuccessfully = "Payment created with id: {0}";
+        public const string PaymentCreatedSuccessfully = "Payment created with id: {0}";
         public const string UserTourCreatedSuccessfully = "UserTour created with id: {0}";
         public const string PaymentIntentCreatedSuccessfully = "PaymentIntent created with id: {0}";
-        public const string PyamentMarkedAsSucceeded = "Payment marked as succeeded with id: {0}";
+        public const string PaymentMarkedAsSucceeded = "Payment marked as succeeded with id: {0}";
     }
 }

--- a/SelfGuidedTours.Common/MessageConstants/LoggerMessages.cs
+++ b/SelfGuidedTours.Common/MessageConstants/LoggerMessages.cs
@@ -4,5 +4,9 @@
     {
         public const string InformationMessageForAllSucessfullyReturnedToursForAdmin = "Sucessfully returned all tours with status {0}!";
         public const string WarningMessageForNotFoundedToursForAdmin = "No tours found!";
+        public const string StripeCustomerCreatedSuccessfully = "Customer created with id: {0}";
+        public const string PaymentCreatetSuccessfully = "Payment created with id: {0}";
+        public const string UserTourCreatedSuccessfully = "UserTour created with id: {0}";
+        public const string PaymentIntentCreatedSuccessfully = "PaymentIntent created with id: {0}";
     }
 }

--- a/SelfGuidedTours.Common/ValidationConstants/ValidationConstants.cs
+++ b/SelfGuidedTours.Common/ValidationConstants/ValidationConstants.cs
@@ -9,17 +9,17 @@
 
             public const int DescriptionMinLength = 10;
             public const int DescriptionMaxLength = 500;
-            
+
             public const int SummaryMinLength = 10;
             public const int SummaryMaxLength = 500;
 
-            public const double PriceMinValue = 1.0;
+            public const double PriceMinValue = 0.0;
 
             public const int ThumbnailImageUrlMaxLength = 500;
 
             public const int LocationMinLength = 3;
             public const int LocationMaxLength = 50;
-            
+
             public const int DestinationMinLength = 3;
             public const int DestinationMaxLength = 50;
 

--- a/SelfGuidedTours.Core/Contracts/IPaymentService.cs
+++ b/SelfGuidedTours.Core/Contracts/IPaymentService.cs
@@ -4,6 +4,6 @@ namespace SelfGuidedTours.Core.Contracts
 {
     public interface IPaymentService
     {
-        Task<ApiResponse> MakePaymentAsync(string userId, PaymentRequest paymentRequest);
+        Task<ApiResponse> MakePaymentAsync(string userId, int tourId);
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IPaymentService.cs
+++ b/SelfGuidedTours.Core/Contracts/IPaymentService.cs
@@ -8,8 +8,10 @@ namespace SelfGuidedTours.Core.Contracts
     {
         Task<ApiResponse> MakePaymentAsync(string userId, int tourId);
 
-        Task<ApiResponse> FinalizePaymentAsync(string userId, FinalizePaymentRequest paymentRequest);
+        Task<ApiResponse> FinalizePaymentAsync(string paymentIndentId);
 
         Task<string> CreateOrGetCustomerAsync(string userId);
+
+        Task<ApiResponse> AddFreeTour(string userId, int tourId);
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IPaymentService.cs
+++ b/SelfGuidedTours.Core/Contracts/IPaymentService.cs
@@ -1,9 +1,15 @@
 ﻿using SelfGuidedTours.Core.Models;
+using SelfGuidedTours.Core.Models.Dto;
+using Stripe;
 
 namespace SelfGuidedTours.Core.Contracts
 {
     public interface IPaymentService
     {
         Task<ApiResponse> MakePaymentAsync(string userId, int tourId);
+
+        Task<ApiResponse> FinalizePaymentAsync(string userId, FinalizePaymentRequest paymentRequest);
+
+        Task<string> CreateOrGetCustomerAsync(string userId);
     }
 }

--- a/SelfGuidedTours.Core/Models/Dto/FinalizePaymentRequest.cs
+++ b/SelfGuidedTours.Core/Models/Dto/FinalizePaymentRequest.cs
@@ -1,8 +1,0 @@
-﻿namespace SelfGuidedTours.Core.Models.Dto
-{
-    public class FinalizePaymentRequest
-    {
-        public string PaymentIntentId { get; set; } = null!;
-        public int TourId { get; set; }
-    }
-}

--- a/SelfGuidedTours.Core/Models/Dto/FinalizePaymentRequest.cs
+++ b/SelfGuidedTours.Core/Models/Dto/FinalizePaymentRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace SelfGuidedTours.Core.Models.Dto
+{
+    public class FinalizePaymentRequest
+    {
+        public string PaymentIntentId { get; set; } = null!;
+        public int TourId { get; set; }
+    }
+}

--- a/SelfGuidedTours.Core/Services/AdminService.cs
+++ b/SelfGuidedTours.Core/Services/AdminService.cs
@@ -63,7 +63,7 @@ namespace SelfGuidedTours.Core.Services
                 throw new KeyNotFoundException(WarningMessageForNotFoundedToursForAdmin);
             }
 
-            logger.LogInformation(InformationMessageForAllSucessfullyReturnedToursForAdmin, status);
+            logger.LogInformation(InformationMessageForAllSuccessfullyReturnedToursForAdmin, status);
 
             return tours;
         }

--- a/SelfGuidedTours.Core/Services/PaymentService.cs
+++ b/SelfGuidedTours.Core/Services/PaymentService.cs
@@ -128,7 +128,7 @@ namespace SelfGuidedTours.Core.Services
             payment.UpdatedAt = DateTime.Now;
             await _repository.UpdateAsync(payment);
 
-            logger.LogInformation(PyamentMarkedAsSucceeded, payment.PaymentId);
+            logger.LogInformation(PaymentMarkedAsSucceeded, payment.PaymentId);
 
             await _repository.AddAsync(userTours);
             await _repository.SaveChangesAsync();

--- a/SelfGuidedTours.Core/Services/PaymentService.cs
+++ b/SelfGuidedTours.Core/Services/PaymentService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models;
+using SelfGuidedTours.Core.Models.Dto;
 using SelfGuidedTours.Infrastructure.Common;
 using SelfGuidedTours.Infrastructure.Data.Models;
 using Stripe;
@@ -12,31 +13,114 @@ namespace SelfGuidedTours.Core.Services
     public class PaymentService : IPaymentService
     {
         private readonly IRepository _repository;
+        private readonly IStripeClient stripeClient;
         private readonly ApiResponse _response;
 
-        public PaymentService(IRepository repository)
+        public PaymentService(IRepository repository, IStripeClient stripeClient)
         {
             _repository = repository;
+            this.stripeClient = stripeClient;
             _response = new ApiResponse();
+        }
+        /// <summary>
+        /// Creates or finds an already existing  stripe customer and asssociated with the current user
+        /// </summary>
+        /// <param name="userId">Id of the current user</param>
+        /// <returns>Id of the Stripe Customer </returns>
+        /// <exception cref="ArgumentException"></exception>
+        public async Task<string> CreateOrGetCustomerAsync(string userId)
+        {
+            var user = _repository.All<ApplicationUser>().FirstOrDefault(u => u.Id == userId)
+                ?? throw new ArgumentException("User not found!");
+
+            //Check if we already have a stripe customer accout associated with the user, return it
+            if (!string.IsNullOrEmpty(user.StripeCustomerId))
+            {
+                return user.StripeCustomerId;
+            }
+
+            //If the user does not have a stripe customer id, create one
+            var customerOptions = new CustomerCreateOptions
+            {
+                Email = user.Email,
+                Name = user.UserName,
+                Description = "Customer for Jauntster",
+            };
+
+            var customerService = new CustomerService(stripeClient);
+
+            var customer = await customerService.CreateAsync(customerOptions);
+
+            user.StripeCustomerId = customer.Id;
+
+            await _repository.UpdateAsync(user);
+            await _repository.SaveChangesAsync();
+
+            return customer.Id;
+        }
+
+        public async Task<ApiResponse> FinalizePaymentAsync(string userId, FinalizePaymentRequest paymentRequest)
+        {
+            if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(paymentRequest.PaymentIntentId))
+                throw new ArgumentNullException("Invalid payment request!");
+
+            var user = _repository.All<ApplicationUser>().FirstOrDefault(u => u.Id == userId)
+                ?? throw new ArgumentException("User not found!");
+
+
+            // Check if the tour is already purchased by the user
+            var existingPayment = await _repository.All<UserTours>()
+                 .FirstOrDefaultAsync(ut => ut.UserId == userId && ut.TourId == paymentRequest.TourId);
+
+            if (existingPayment != null)
+                throw new InvalidOperationException("Tour already purchased!");
+
+            var tour = await _repository.All<Tour>().FirstOrDefaultAsync(t => t.TourId == paymentRequest.TourId)
+                    ?? throw new InvalidOperationException("Tour not found!");
+
+            if (!tour.Price.HasValue)
+                throw new InvalidOperationException("Tour price is not set!");
+
+            var payment = new Payment
+            {
+                UserId = userId,
+                TourId = paymentRequest.TourId,
+                PaymentIntentId = paymentRequest.PaymentIntentId,
+                Amount = tour.Price.Value,
+                PaymentDate = DateTime.Now
+            };
+
+            var userTours = new UserTours
+            {
+                UserId = userId,
+                TourId = paymentRequest.TourId,
+                PurchaseDate = DateTime.Now,
+            };
+
+            await _repository.AddAsync(userTours);
+            await _repository.AddAsync(payment);
+            await _repository.SaveChangesAsync();
+
+            _response.StatusCode = HttpStatusCode.OK;
+            _response.IsSuccess = true;
+            _response.Result = new { Message = "Payment successful!" };
+
+            return _response;
         }
 
 
         public async Task<ApiResponse> MakePaymentAsync(string userId, int tourId)
         {
-            
+
             if (string.IsNullOrEmpty(userId) || tourId <= 0)
-                            throw new ArgumentNullException("Invalid payment request!");
+                throw new ArgumentNullException("Invalid payment request!");
 
             // Check if the user exists
             var userExists = await _repository.All<ApplicationUser>().AnyAsync(u => u.Id == userId);
-            if (!userExists)
-                throw new ArgumentException("User not found!");
 
-            // Check if the tour is already purchased by the user
-            //var existingPayment = await _repository.All<Payment>()
-            //    .FirstOrDefaultAsync(p => p.UserId == userId && p.TourId == tourId);
-            //if (existingPayment != null)
-            //    throw new InvalidOperationException("Tour already purchased!");
+            if (!userExists)
+                throw new InvalidOperationException("User not found!");
+
 
             // Check if Tour Exists
             var tour = await _repository.All<Tour>()
@@ -52,6 +136,8 @@ namespace SelfGuidedTours.Core.Services
                 return _response;
             }
 
+            string customerId = await CreateOrGetCustomerAsync(userId);
+
             #region Create Payment Intent
 
             PaymentIntentCreateOptions options = new()
@@ -62,32 +148,23 @@ namespace SelfGuidedTours.Core.Services
                 [
                     "card",
                 ],
+                Customer = customerId,
             };
 
-            PaymentIntentService service = new();
+            PaymentIntentService service = new(stripeClient);
+
             PaymentIntent stripeResponse = await service.CreateAsync(options);
+
+
+            #endregion
 
             var paymentResult = new PaymentResult
             {
                 PaymentIntentId = stripeResponse.Id,
                 ClientSecret = stripeResponse.ClientSecret,
                 Amount = tour.Price.Value
+
             };
-
-            // Save payment information in the database
-            var payment = new Payment
-            {
-                UserId = userId,
-                TourId = tourId,
-                PaymentIntentId = stripeResponse.Id,
-                Amount = tour.Price.Value,
-                PaymentDate = DateTime.Now
-            };
-
-            await _repository.AddAsync(payment);
-            await _repository.SaveChangesAsync();
-
-            #endregion
 
             _response.Result = paymentResult;
             _response.StatusCode = HttpStatusCode.OK;

--- a/SelfGuidedTours.Core/Services/PaymentService.cs
+++ b/SelfGuidedTours.Core/Services/PaymentService.cs
@@ -18,13 +18,18 @@ namespace SelfGuidedTours.Core.Services
         private readonly IRepository _repository;
         private readonly IStripeClient stripeClient;
         private readonly ILogger<PaymentService> logger;
+        private readonly CustomerService customerService;
+        private readonly PaymentIntentService paymentIntentService;
         private readonly ApiResponse _response;
 
-        public PaymentService(IRepository repository, IStripeClient stripeClient, ILogger<PaymentService> logger)
+        public PaymentService(IRepository repository, IStripeClient stripeClient, ILogger<PaymentService> logger,
+            CustomerService customerService, PaymentIntentService paymentIntentService)
         {
             _repository = repository;
             this.stripeClient = stripeClient;
             this.logger = logger;
+            this.customerService = customerService;
+            this.paymentIntentService = paymentIntentService;
             _response = new ApiResponse();
         }
 
@@ -82,7 +87,7 @@ namespace SelfGuidedTours.Core.Services
                 Description = CustomerDescription,
             };
 
-            var customerService = new CustomerService(stripeClient);
+           // var customerService = new CustomerService(stripeClient);
 
             var customer = await customerService.CreateAsync(customerOptions);
 
@@ -171,10 +176,9 @@ namespace SelfGuidedTours.Core.Services
                 Customer = customerId,
             };
 
-            PaymentIntentService service = new(stripeClient);
 
 
-            PaymentIntent stripeResponse = await service.CreateAsync(options);
+            PaymentIntent stripeResponse = await paymentIntentService.CreateAsync(options);
 
             logger.LogInformation(PaymentIntentCreatedSuccessfully, stripeResponse.Id);
 

--- a/SelfGuidedTours.Core/Services/PaymentService.cs
+++ b/SelfGuidedTours.Core/Services/PaymentService.cs
@@ -57,7 +57,7 @@ namespace SelfGuidedTours.Core.Services
 
             _response.StatusCode = HttpStatusCode.OK;
             _response.IsSuccess = true;
-            _response.Result = new { Message = FreeTourAddedMessage };
+            _response.Result = FreeTourAddedMessage;
 
             return _response;
         }
@@ -158,7 +158,7 @@ namespace SelfGuidedTours.Core.Services
                         ?? throw new InvalidOperationException(TourNotFoundMessage);
 
             // Check if the tour price is set
-            if (!tour.Price.HasValue)
+            if (!tour.Price.HasValue || tour.Price == 0)
                 throw new InvalidOperationException(TourPriceNotSetMessage);
 
             string customerId = await CreateOrGetCustomerAsync(userId);

--- a/SelfGuidedTours.Core/Services/PaymentService.cs
+++ b/SelfGuidedTours.Core/Services/PaymentService.cs
@@ -13,20 +13,17 @@ namespace SelfGuidedTours.Core.Services
     {
         private readonly IRepository _repository;
         private readonly ApiResponse _response;
-        private readonly IConfiguration _configuration;
 
-        public PaymentService(IRepository repository, IConfiguration configuration)
+        public PaymentService(IRepository repository)
         {
             _repository = repository;
-            _configuration = configuration;
             _response = new ApiResponse();
-
-            // Load Stripe API key from configuration
-            StripeConfiguration.ApiKey = _configuration["StripeSettings:SecretKey"];
         }
+
 
         public async Task<ApiResponse> MakePaymentAsync(string userId, PaymentRequest paymentRequest)
         {
+            
             if (paymentRequest == null || string.IsNullOrEmpty(userId) || paymentRequest.TourId <= 0)
             {
                 _response.StatusCode = HttpStatusCode.BadRequest;

--- a/SelfGuidedTours.Infrastructure/Data/Enums/PaymentStatus.cs
+++ b/SelfGuidedTours.Infrastructure/Data/Enums/PaymentStatus.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SelfGuidedTours.Infrastructure.Data.Enums
+{
+    public enum PaymentStatus
+    {
+        Pending,
+        Succeeded,
+        Failed
+    }
+}

--- a/SelfGuidedTours.Infrastructure/Data/Models/ApplicationUser.cs
+++ b/SelfGuidedTours.Infrastructure/Data/Models/ApplicationUser.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 
 namespace SelfGuidedTours.Infrastructure.Data.Models
@@ -6,6 +7,8 @@ namespace SelfGuidedTours.Infrastructure.Data.Models
     public class ApplicationUser : IdentityUser
     {
         public string Name { get; set; } = null!;
+        [Comment("Id of the stripe customer associated with the user. Created when the user makes a payment.")]
+        public string? StripeCustomerId { get; set; }
         public string? Credentials { get; set; }
         [Required]
         public DateTime CreatedAt { get; set; } = DateTime.Now;

--- a/SelfGuidedTours.Infrastructure/Data/Models/Payment.cs
+++ b/SelfGuidedTours.Infrastructure/Data/Models/Payment.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using SelfGuidedTours.Infrastructure.Data.Enums;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace SelfGuidedTours.Infrastructure.Data.Models
@@ -21,6 +22,7 @@ namespace SelfGuidedTours.Infrastructure.Data.Models
         [Required]
         [Column(TypeName = "decimal(10, 2)")]
         public decimal Amount { get; set; }
+        public PaymentStatus Status { get; set; } = PaymentStatus.Pending;
 
         [Required]
         public DateTime PaymentDate { get; set; } = DateTime.Now;

--- a/SelfGuidedTours.Infrastructure/Migrations/20240814144455_Add stripe customer id to Application user.Designer.cs
+++ b/SelfGuidedTours.Infrastructure/Migrations/20240814144455_Add stripe customer id to Application user.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SelfGuidedTours.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using SelfGuidedTours.Infrastructure.Data;
 namespace SelfGuidedTours.Infrastructure.Migrations
 {
     [DbContext(typeof(SelfGuidedToursDbContext))]
-    partial class SelfGuidedToursDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240814144455_Add stripe customer id to Application user")]
+    partial class AddstripecustomeridtoApplicationuser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -465,9 +468,6 @@ namespace SelfGuidedTours.Infrastructure.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("TourId"));
 
-                    b.Property<decimal>("AverageRating")
-                        .HasColumnType("decimal(3, 2)");
-
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
 
@@ -505,9 +505,6 @@ namespace SelfGuidedTours.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
-
-                    b.Property<int>("TypeTour")
-                        .HasColumnType("int");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");

--- a/SelfGuidedTours.Infrastructure/Migrations/20240814144455_Add stripe customer id to Application user.cs
+++ b/SelfGuidedTours.Infrastructure/Migrations/20240814144455_Add stripe customer id to Application user.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SelfGuidedTours.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddstripecustomeridtoApplicationuser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "StripeCustomerId",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true,
+                comment: "Id of the stripe customer associated with the user. Created when the user makes a payment.");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "27d78708-8671-4b05-bd5e-17aa91392224",
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "PasswordHash", "SecurityStamp", "StripeCustomerId" },
+                values: new object[] { "bb536c99-ccf7-49f8-bc11-afac48d98097", new DateTime(2024, 8, 14, 17, 44, 54, 144, DateTimeKind.Local).AddTicks(8595), "AQAAAAIAAYagAAAAEGz1RIhj8HQ0JnO9NfoD2QRhC4nadnBCra2nZZvjdCHwu4UG3xaFpBcBmktpimV8sQ==", "54e3bfdc-92c8-44c6-b612-08482e2fd5b5", null });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StripeCustomerId",
+                table: "AspNetUsers");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "27d78708-8671-4b05-bd5e-17aa91392224",
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "a7b6015d-87bc-4ec8-a030-23662c71d6c4", new DateTime(2024, 7, 4, 0, 55, 26, 579, DateTimeKind.Local).AddTicks(1943), "AQAAAAIAAYagAAAAEOswFRbfWYRU+ZLW+T+kJAA7FBcSpoDhxJLn9PUdGndbBkElyPylMKH77IHVJMTofg==", "943d7b20-66ee-408a-95be-62edcd64628e" });
+        }
+    }
+}

--- a/SelfGuidedTours.Infrastructure/Migrations/20240815081234_Add status field in Payment table.Designer.cs
+++ b/SelfGuidedTours.Infrastructure/Migrations/20240815081234_Add status field in Payment table.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SelfGuidedTours.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using SelfGuidedTours.Infrastructure.Data;
 namespace SelfGuidedTours.Infrastructure.Migrations
 {
     [DbContext(typeof(SelfGuidedToursDbContext))]
-    partial class SelfGuidedToursDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240815081234_Add status field in Payment table")]
+    partial class AddstatusfieldinPaymenttable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SelfGuidedTours.Infrastructure/Migrations/20240815081234_Add status field in Payment table.cs
+++ b/SelfGuidedTours.Infrastructure/Migrations/20240815081234_Add status field in Payment table.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SelfGuidedTours.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddstatusfieldinPaymenttable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "Payments",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "27d78708-8671-4b05-bd5e-17aa91392224",
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "ee5b71d5-3af1-44f6-b4d6-fd68f6a3960a", new DateTime(2024, 8, 15, 11, 12, 33, 549, DateTimeKind.Local).AddTicks(7512), "AQAAAAIAAYagAAAAEOwdPeaWXYW4ySRQhGR0MkNWDhygpRIt3bSAiKlBfp3zJCCnebmtOwNbvD9dHKDRyw==", "6304ad3e-c51d-42a1-87ba-a8ebc4085707" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Payments");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "27d78708-8671-4b05-bd5e-17aa91392224",
+                columns: new[] { "ConcurrencyStamp", "CreatedAt", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "bb536c99-ccf7-49f8-bc11-afac48d98097", new DateTime(2024, 8, 14, 17, 44, 54, 144, DateTimeKind.Local).AddTicks(8595), "AQAAAAIAAYagAAAAEGz1RIhj8HQ0JnO9NfoD2QRhC4nadnBCra2nZZvjdCHwu4UG3xaFpBcBmktpimV8sQ==", "54e3bfdc-92c8-44c6-b612-08482e2fd5b5" });
+        }
+    }
+}

--- a/SelfGuidedTours.Tests/UnitTests/AuthServiceTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/AuthServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Moq;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.CustomExceptions;
 using SelfGuidedTours.Core.Models.Auth;
@@ -30,7 +31,7 @@ namespace SelfGuidedTours.Tests.UnitTests
         private TokenGenerator tokenGenerator;
         private ILoggerFactory loggerFactory;
         private IProfileService profileService;
-        private readonly UserManager<ApplicationUser>? userManager = null;
+        private  Mock<UserManager<ApplicationUser>> mockUserManager;
         private IdentityRole[] roles;
 
         private IEnumerable<ApplicationUser> users;
@@ -46,6 +47,10 @@ namespace SelfGuidedTours.Tests.UnitTests
         public async Task SetupAsync()
         {
             var hasher = new PasswordHasher<ApplicationUser>();
+
+             var store = new Mock<IUserStore<ApplicationUser>>();
+
+            mockUserManager = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
 
             #region User and Admin initializing
 
@@ -72,8 +77,8 @@ namespace SelfGuidedTours.Tests.UnitTests
             #endregion
             roles =
             [
-                new IdentityRole("User"),
-                new IdentityRole("Admin")
+                new IdentityRole("4f8554d2-cfaa-44b5-90ce-e883c804ae90"), // User
+                new IdentityRole("656a6079-ec9a-4a98-a484-2d1752156d60") // Admin
             ];
             var useRole = new IdentityUserRole<string>()
             {
@@ -111,12 +116,14 @@ namespace SelfGuidedTours.Tests.UnitTests
             refreshTokenService = new RefreshTokenService(repository);
             logger = new Logger<AuthService>(loggerFactory);
 
-            profileService = new ProfileService(repository, userManager!);
+            profileService = new ProfileService(repository, mockUserManager.Object);
 
             // AuthService initialized
             service = new AuthService(repository, accessTokenGenerator,
-                refreshTokenGenerator, refreshTokenValidator, refreshTokenService, profileService, userManager, logger);
+                refreshTokenGenerator, refreshTokenValidator, refreshTokenService, profileService, mockUserManager.Object, logger);
 
+            mockUserManager.Setup(m => m.FindByEmailAsync(It.IsAny<string>())).ReturnsAsync((string email) => users.SingleOrDefault(u => u.Email == email));
+            mockUserManager.Setup(m => m.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync("MockToken");
             // Environment Variables
             Environment.SetEnvironmentVariable("ACCESSTOKEN_KEY", "4y7XS2AHicSOs2uUJCxwlHWqTJNExW3UDUjMeXi96uLEso1YV4RazqQubpFBdx0zZGtdxBelKURhh0WXxPR0mEJQHk_0U9HeYtqcMManhoP3X2Ge8jgxh6k4C_Gd4UPTc6lkx0Ca5eRE16ciFQ6wmYDnaXC8NbngGqartHccAxE");
             Environment.SetEnvironmentVariable("ACCESSTOKEN_EXPIRATIONMINUTES", "50");

--- a/SelfGuidedTours.Tests/UnitTests/EmailServiceTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/EmailServiceTests.cs
@@ -1,6 +1,8 @@
-﻿using Castle.Core.Configuration;
+﻿using Microsoft.Extensions.Configuration;
+using Moq;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models;
+using SelfGuidedTours.Core.Services;
 
 namespace SelfGuidedTours.Tests.UnitTests
 {
@@ -8,12 +10,14 @@ namespace SelfGuidedTours.Tests.UnitTests
     public class EmailServiceTests
     {
         private IEmailService emailService;
+        private Mock<IConfiguration> cofigurationMock;
 
         [SetUp]
         public void Setup()
         {
-            emailService = new EmailService();//TODO...Fix later. Constructor expects IConfiguration...
-
+            
+            cofigurationMock = new Mock<IConfiguration>();
+            emailService = new EmailService(cofigurationMock.Object);
             // Set environment variables for testing
             Environment.SetEnvironmentVariable("ASPNETCORE_SMTP_USERNAME", "testuser@example.com");
             Environment.SetEnvironmentVariable("ASPNETCORE_SMTP_HOST", "smtp.example.com");

--- a/SelfGuidedTours.Tests/UnitTests/PaymentServiceTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/PaymentServiceTests.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SelfGuidedTours.Core.Contracts;
+using SelfGuidedTours.Core.Models;
+using SelfGuidedTours.Core.Services;
+using SelfGuidedTours.Infrastructure.Common;
+using SelfGuidedTours.Infrastructure.Data;
+using SelfGuidedTours.Infrastructure.Data.Enums;
+using SelfGuidedTours.Infrastructure.Data.Models;
+using Stripe;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SelfGuidedTours.Tests.UnitTests
+{
+    [TestFixture]
+    public class PaymentServiceTests
+    {
+        private IPaymentService paymentService;
+        [SetUp]
+        public async Task SetupAsync()
+        {
+            //setup db
+            var dbContextOptions = new DbContextOptionsBuilder<SelfGuidedToursDbContext>()
+                       .UseInMemoryDatabase("SelfGuidedToursInMemoryDb"
+                           + Guid.NewGuid().ToString())
+                       .Options;
+            var dbContext = new SelfGuidedToursDbContext(dbContextOptions);
+
+            IRepository repository = new Repository(dbContext);
+
+            var mockedStripeClient = new Mock<IStripeClient>();
+              
+            var mockedLogger = new Mock<ILogger<PaymentService>>();
+            paymentService = new PaymentService(repository,mockedStripeClient.Object,mockedLogger.Object);
+            // Seed data
+            var users = new List<ApplicationUser>
+            {
+                new ApplicationUser
+                {
+                    Id = "testuserId",
+                    Email = "test@da.b",
+                    UserName = "testuserCreator",
+                    CreatedAt = DateTime.Now,
+                    Name = "Test User",
+                    PhoneNumber = "1234567890",
+                },
+                new ApplicationUser
+                {
+                    Id = "testuserId2",
+                    Email = "test2@da.b",
+                    UserName = "testuserCreator2",
+                    CreatedAt = DateTime.Now,
+                    Name = "Test User 2",
+                    PhoneNumber = "1234567890",
+                }
+            };
+            var tours = new List<Tour>
+            {
+                new Tour
+                {
+                    TourId = 1,
+                    Title = "Test Tour",
+                    ThumbnailImageUrl = "https://example.com/image.jpg",
+                    Summary = "Test Summary",
+                    Status = Status.UnderReview,
+                    CreatedAt = DateTime.Now,
+                    CreatorId = "testuserId",
+                    Destination="test",
+                    EstimatedDuration=134,
+                    Price=100,
+                },
+                new Tour
+                {
+                    TourId = 2,
+                    Title = "Test Tour 2",
+                    ThumbnailImageUrl = "https://example.com/image2.jpg",
+                    Summary = "Test Summary 2",
+                    Status = Status.Approved,
+                    CreatedAt = DateTime.Now,
+                    CreatorId = "testuserId",
+                    Destination="test",
+                    EstimatedDuration=134,
+                    Price=200,
+                }
+            };
+            await dbContext.Users.AddRangeAsync(users);
+            await dbContext.Tours.AddRangeAsync(tours);
+            await dbContext.SaveChangesAsync();
+
+
+        }
+        [Test]
+        public async Task MakePaymentAsync_ShouldReturnApiResponse_WhenCalled()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+
+            // Act
+            var response = await paymentService.MakePaymentAsync(userId, tourId);
+            // Assert
+            Assert.IsInstanceOf<ApiResponse>(response);
+        }
+    }
+}

--- a/SelfGuidedTours.Tests/UnitTests/PaymentServiceTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/PaymentServiceTests.cs
@@ -21,6 +21,7 @@ namespace SelfGuidedTours.Tests.UnitTests
     public class PaymentServiceTests
     {
         private IPaymentService paymentService;
+        private  IRepository repository;
         [SetUp]
         public async Task SetupAsync()
         {
@@ -31,12 +32,30 @@ namespace SelfGuidedTours.Tests.UnitTests
                        .Options;
             var dbContext = new SelfGuidedToursDbContext(dbContextOptions);
 
-            IRepository repository = new Repository(dbContext);
+            repository = new Repository(dbContext);
 
+            var testCustomer = new Customer
+            {
+                Id = "cus_test123",
+                Email = "test@example.com",
+                Name = "Test Customer"
+            };
+
+
+
+            // Mock dependencies
             var mockedStripeClient = new Mock<IStripeClient>();
-              
+            var mockedPaymentIntentService = new Mock<PaymentIntentService>();
+            var mockedCustomerService = new Mock<CustomerService>(MockBehavior.Strict);
+            // Mock CreateAsync method to always return a customer
+            mockedCustomerService.Setup(x => x.CreateAsync(It.IsAny<CustomerCreateOptions>(),null,It.IsAny<CancellationToken>())).ReturnsAsync(testCustomer);
+            mockedPaymentIntentService.Setup(service => service.CreateAsync(It.IsAny<PaymentIntentCreateOptions>(), null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PaymentIntent() { Id = "pi_test123" });
+
             var mockedLogger = new Mock<ILogger<PaymentService>>();
-            paymentService = new PaymentService(repository,mockedStripeClient.Object,mockedLogger.Object);
+
+            paymentService = new PaymentService(repository, mockedStripeClient.Object, mockedLogger.Object,
+                mockedCustomerService.Object, mockedPaymentIntentService.Object);
             // Seed data
             var users = new List<ApplicationUser>
             {
@@ -86,6 +105,31 @@ namespace SelfGuidedTours.Tests.UnitTests
                     Destination="test",
                     EstimatedDuration=134,
                     Price=200,
+                },
+                new Tour
+                {
+                    TourId = 3,
+                    Title = "Test Tour 3",
+                    ThumbnailImageUrl = "https://example.com/image3.jpg",
+                    Summary = "Test Summary 3",
+                    Status = Status.Approved,
+                    CreatedAt = DateTime.Now,
+                    CreatorId = "testuserId",
+                    Destination="test",
+                    EstimatedDuration=134,
+                },
+                new Tour
+                {
+                    TourId = 4,
+                    Title = "Test Tour 4",
+                    ThumbnailImageUrl = "https://example.com/image4.jpg",
+                    Summary = "Test Summary 4",
+                    Status = Status.Approved,
+                    CreatedAt = DateTime.Now,
+                    CreatorId = "testuserId",
+                    Destination="test",
+                    EstimatedDuration=134,
+                    Price=0,
                 }
             };
             await dbContext.Users.AddRangeAsync(users);
@@ -100,11 +144,369 @@ namespace SelfGuidedTours.Tests.UnitTests
             // Arrange
             var userId = "testuserId";
             var tourId = 1;
-
             // Act
             var response = await paymentService.MakePaymentAsync(userId, tourId);
             // Assert
-            Assert.IsInstanceOf<ApiResponse>(response);
+            Assert.That(response, Is.InstanceOf<ApiResponse>());
         }
+        [Test]
+        public async Task MakePaymentAsync_ShouldReturnApiResponseWithSuccessTrue_WhenCalled()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            // Act
+            var response = await paymentService.MakePaymentAsync(userId, tourId);
+            // Assert
+            Assert.That(response.IsSuccess, Is.True);
+        }
+        [Test]
+        public  void MakePaymentAsync_ShouldReturnUserNotFountMessage_WhenUserDoesNotExist()
+        {
+            // Arrange
+            var userId = "testuserId3";
+            var tourId = 1;
+            // Act
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(()=>paymentService.MakePaymentAsync(userId,tourId));
+            
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("User not found!"));
+        }
+
+        [Test]
+        public void MakePaymentAsync_ShouldReturnTourNotFoundMessage_WhenTourDoesNotExist()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 332;
+            // Act
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(() => paymentService.MakePaymentAsync(userId, tourId));
+
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("Tour not found!"));
+        }
+        [Test]
+        public void MakePaymentAsync_ShouldReturnTourPriceNotSetMessage_WhenTourPriceIsNotSet()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 3; // tour with no price
+            // Act
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(() => paymentService.MakePaymentAsync(userId, tourId));
+
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("Tour price is not set!"));
+        }
+        [Test]
+        public async Task MakePaymentAsync_ShouldCreatePaymentIntent_WhenCalled()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            // Act
+            var response = await paymentService.MakePaymentAsync(userId, tourId);
+            // Assert
+            Assert.That(response.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public async Task MakePaymentAsync_ShouldCreatePayment()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            var paymentsCount = await repository.All<Payment>().CountAsync();
+            // Act
+            var response = await paymentService.MakePaymentAsync(userId, tourId);
+            var newPaymentsCount = await repository.All<Payment>().CountAsync();
+            // Assert
+            Assert.That(newPaymentsCount, Is.EqualTo(paymentsCount+1));
+        }
+
+        [Test]
+        public async Task MakePaymentAsync_ShouldCreatePaymentWithStatusPending()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            // Act
+            var response = await paymentService.MakePaymentAsync(userId, tourId);
+            var payment = await repository.All<Payment>()
+                .FirstOrDefaultAsync(p=>p.UserId==userId 
+                                       && p.TourId == tourId);
+            // Assert
+            Assert.That(payment!.Status, Is.EqualTo(PaymentStatus.Pending));
+        }
+        [Test]
+        public async Task MakePaymentAsync_ShouldCreatePaymentIntentWithAmount()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+
+            // Act
+            var tour = await repository.All<Tour>().FirstOrDefaultAsync(t=>t.TourId == tourId);
+            var response = await paymentService.MakePaymentAsync(userId, tourId);
+            var paymentResult = response.Result as PaymentResult;
+
+            // Assert
+            Assert.That(paymentResult!.Amount, Is.EqualTo(tour!.Price));
+        }
+        [Test]
+        public void FinalizePaymentAsync_ShouldReturnPaymentNotFound()
+        {
+            // Arrange
+            var paymentIntentId = "wrong payment id";
+            // Act
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(() => paymentService.FinalizePaymentAsync(paymentIntentId));
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("Payment not found!"));
+        }
+        [Test]
+        public async Task FinalizePaymentAsync_ShouldReturnTourAlreadyPurchased()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            var payment = new Payment
+            {
+                PaymentId = 123,
+                UserId = userId,
+                TourId = tourId,
+                PaymentIntentId = "pi_test123",
+                Status = PaymentStatus.Succeeded,
+                PaymentDate = DateTime.Now,
+            };
+            await repository.AddAsync(payment);
+            await repository.SaveChangesAsync();
+            // Act
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(() => paymentService.FinalizePaymentAsync("pi_test123"));
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("Tour already purchased!"));
+        }
+        [Test]
+        public async Task FinalizePaymentAsync_ShouldReturnApiResponse()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            var payment = new Payment
+            {
+                PaymentId = 123,
+                UserId = userId,
+                TourId = tourId,
+                PaymentIntentId = "pi_test123",
+                Status = PaymentStatus.Pending,
+                PaymentDate = DateTime.Now,
+            };
+            await repository.AddAsync(payment);
+            await repository.SaveChangesAsync();
+            // Act
+            var response = await paymentService.FinalizePaymentAsync("pi_test123");
+            // Assert
+            Assert.That(response, Is.InstanceOf<ApiResponse>());
+        }
+        [Test]
+        public async Task FinalizePaymentAsync_ShouldReturnApiResponseWithSuccessTrue()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            var payment = new Payment
+            {
+                PaymentId = 123,
+                UserId = userId,
+                TourId = tourId,
+                PaymentIntentId = "pi_test123",
+                Status = PaymentStatus.Pending,
+                PaymentDate = DateTime.Now,
+            };
+            await repository.AddAsync(payment);
+            await repository.SaveChangesAsync();
+            // Act
+            var response = await paymentService.FinalizePaymentAsync("pi_test123");
+            // Assert
+            Assert.That(response.IsSuccess, Is.True);
+        }
+        [Test]
+        public async Task FinalizePaymentAsync_ShouldReturnPaymentMarkedAsSucceeded()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            var payment = new Payment
+            {
+                PaymentId = 123,
+                UserId = userId,
+                TourId = tourId,
+                PaymentIntentId = "pi_test123",
+                Status = PaymentStatus.Pending,
+                PaymentDate = DateTime.Now,
+            };
+            await repository.AddAsync(payment);
+            await repository.SaveChangesAsync();
+            // Act
+            var response = await paymentService.FinalizePaymentAsync("pi_test123");
+            var updatedPayment = await repository.All<Payment>().FirstOrDefaultAsync(p => p.PaymentIntentId == "pi_test123");
+            // Assert
+            Assert.That(updatedPayment!.Status, Is.EqualTo(PaymentStatus.Succeeded));
+        }
+        [Test]
+        public async Task FinalizePaymentAsync_ShouldCreateUserTour()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            var payment = new Payment
+            {
+                PaymentId = 123,
+                UserId = userId,
+                TourId = tourId,
+                PaymentIntentId = "pi_test123",
+                Status = PaymentStatus.Pending,
+                PaymentDate = DateTime.Now,
+            };
+            await repository.AddAsync(payment);
+            await repository.SaveChangesAsync();
+            // Act
+            var response = await paymentService.FinalizePaymentAsync("pi_test123");
+            var userTour = await repository.All<UserTours>().FirstOrDefaultAsync(ut => ut.UserId == userId && ut.TourId == tourId);
+            // Assert
+            Assert.That(userTour, Is.Not.Null);
+        }
+        [Test]
+        public async Task CreateOrGetCustomerAsync_ShouldReturnUserNotFound()
+        {
+            // Arrange
+            var userId = "wrongUserId";
+            // Act
+            var ex = Assert.ThrowsAsync<ArgumentException>(() => paymentService.CreateOrGetCustomerAsync(userId));
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("User not found!"));
+        }
+        [Test]
+        public async Task CreateOrGetCustomerAsync_ShouldReturnCustomer()
+        {
+            // Arrange
+            var userId = "testuserId";
+            // Act
+            var customer = await paymentService.CreateOrGetCustomerAsync(userId);
+            // Assert
+            Assert.That(customer, Is.Not.Null);
+        }
+        [Test]
+        public async Task CreateOrGetCustomerAsync_ShouldAddCustomerIdToUser()
+        {
+            // Arrange
+            var userId = "testuserId";
+            // Act
+            var customer = await paymentService.CreateOrGetCustomerAsync(userId);
+            var user = await repository.All<ApplicationUser>().FirstOrDefaultAsync(u => u.Id == userId);
+            // Assert
+            Assert.That(user!.StripeCustomerId, Is.Not.Null);
+        }
+        [Test]
+        public async Task CreateOrGetCustomerAsync_ShouldReturnAlreadyExistinCustomerId()
+        {
+            // Arrange
+            var user = new ApplicationUser
+            {
+                Id = "testuserIdWithCUstomerId",
+                Email = "test@da.b",
+                UserName = "testuserCreator",
+                CreatedAt = DateTime.Now,
+                Name = "Test User",
+                PhoneNumber = "1234567890",
+                StripeCustomerId = "cus_test123"
+            };
+            await repository.AddAsync(user);
+            await repository.SaveChangesAsync();
+
+            //Act
+            var customerId = await paymentService.CreateOrGetCustomerAsync(user.Id);
+
+            //Assert
+            Assert.That(customerId, Is.EqualTo(user.StripeCustomerId));
+        }
+        [Test]
+        public void AddFreeTour_ShouldReturnTourIsNotFree()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 1;
+            // Act
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(() => paymentService.AddFreeTour(userId, tourId));
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("Tour is not free!"));
+        }
+        [Test]
+        public void AddFreeTour_ShouldReturnTourNotFound()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 123;
+            // Act
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(() => paymentService.AddFreeTour(userId, tourId));
+            // Assert
+            Assert.That(ex.Message, Is.EqualTo("Tour not found!"));
+        }
+        [Test]
+        public async Task AddFreeTour_ShouldReturnApiResponse()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 4;
+            // Act
+            var response = await paymentService.AddFreeTour(userId, tourId);
+            // Assert
+            Assert.That(response, Is.InstanceOf<ApiResponse>());
+        }
+        [Test]
+        public async Task AddFreeTour_ShouldReturnApiResponseWithSuccessTrue()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 4;
+            // Act
+            var response = await paymentService.AddFreeTour(userId, tourId);
+            // Assert
+            Assert.That(response.IsSuccess, Is.True);
+        }
+        [Test]
+        public async Task AddFreeTour_ShouldCreateUserTour()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 4;
+            // Act
+            var response = await paymentService.AddFreeTour(userId, tourId);
+            var userTour = await repository.All<UserTours>().FirstOrDefaultAsync(ut => ut.UserId == userId && ut.TourId == tourId);
+            // Assert
+            Assert.That(userTour, Is.Not.Null);
+        }
+        [Test]
+        public async Task AddFreeTour_ShouldReturnUserTourCreatedSuccessfully()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 4;
+            // Act
+            var response = await paymentService.AddFreeTour(userId, tourId);
+            // Assert
+            Assert.That(response.Result, Is.EqualTo("Tour successfully added to collection!" ));
+        }
+        [Test]
+        public async Task AddFreeTour_ShouldReturnUserTourCreatedSuccessfullyWithUserTourId()
+        {
+            // Arrange
+            var userId = "testuserId";
+            var tourId = 4;
+            // Act
+            var response = await paymentService.AddFreeTour(userId, tourId);
+            var userTour = await repository.All<UserTours>().FirstOrDefaultAsync(ut => ut.UserId == userId && ut.TourId == tourId);
+            // Assert
+            Assert.That(response.Result, Is.EqualTo($"Tour successfully added to collection!"));
+        }
+
     }
 }


### PR DESCRIPTION
Moved the payment logic in 3 different methods.
1. MakePaymentAsync creates a payment intent creates a Payment entity with status Pending, it creates a stripe customer account if it doesen't exist and attaches the customer id to the ApplicationUser, i added StripeCustomerId.
2. FinalizePaymentAsync gets called of a webhook event, it updates the Payment entity with
with status Succeeded. It also creates a UserTours entity with the user and the tour.
3. AddFreeTour this handles the case when the tour is free, it checks if tour is actualy free
 if it is it creates a UserTours entity.
I moved the stripe configuration to ServiceCollectionExtensions.cs and added the used services
to the DI container. PaymentService now gets injected with the necessary services, this way we can test it easier.