### PR TITLE
Feature/vot 246 create soft delete endpoint for deleting tours in my tours

### DIFF
--- a/SelfGuidedTours.Api/Controllers/ProfileController.cs
+++ b/SelfGuidedTours.Api/Controllers/ProfileController.cs
@@ -5,12 +5,10 @@ using SelfGuidedTours.Api.CustomActionFilters;
 using SelfGuidedTours.Core.Contracts;
 using SelfGuidedTours.Core.Models;
 using SelfGuidedTours.Core.Models.Dto;
+using SelfGuidedTours.Core.Models.ErrorResponse;
 using SelfGuidedTours.Core.Models.RequestDto;
 using SelfGuidedTours.Core.Models.ResponseDto;
 using SelfGuidedTours.Infrastructure.Data.Models;
-using System;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace SelfGuidedTours.Api.Controllers
 {
@@ -83,6 +81,16 @@ namespace SelfGuidedTours.Api.Controllers
             return transactions == null ? NotFound() : Ok(transactions);
         }
 
-        
+        [HttpPatch("delete-my-tour/{id:int}", Name = "delete-my-tour")]
+        [ProducesResponseType(typeof(ApiResponse), 200)]
+        [ProducesResponseType(typeof(ErrorDetails), 400)]
+        [ProducesResponseType(typeof(ErrorDetails), 404)]
+        [ProducesResponseType(401)]
+        public async Task<IActionResult> DeleteTour([FromRoute] int id)
+        {
+            var result = await _profileService.DeleteTourAsync(id, this.UserId);
+
+            return StatusCode((int)result.StatusCode, result);
+        }
     }
 }

--- a/SelfGuidedTours.Core/Contracts/IProfileService.cs
+++ b/SelfGuidedTours.Core/Contracts/IProfileService.cs
@@ -15,7 +15,9 @@ namespace SelfGuidedTours.Core.Contracts
         Task<ApiResponse> GetMyToursAsync(string userId, int page, int pageSize);
         Task<ApiResponse> GetBoughtToursAsync(string userId, int page, int pageSize);
         Task<ApiResponse> GetUserTransactionsAsync(string userId, int page, int pageSize);
-       // Task<ApiResponse> ChangePasswordAsync(string userId, CreateOrChangePasswordRequestDto changePasswordRequest);
+        // Task<ApiResponse> ChangePasswordAsync(string userId, CreateOrChangePasswordRequestDto changePasswordRequest);
+
+        Task<ApiResponse> DeleteTourAsync(int tourId, string userId);
 
     }
 }

--- a/SelfGuidedTours.Infrastructure/Data/Enums/Status.cs
+++ b/SelfGuidedTours.Infrastructure/Data/Enums/Status.cs
@@ -4,6 +4,7 @@
     {
         UnderReview,
         Approved,
-        Declined
+        Declined,
+        Deleted
     }
 }

--- a/SelfGuidedTours.Tests/UnitTests/AuthServiceTests.cs
+++ b/SelfGuidedTours.Tests/UnitTests/AuthServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -128,9 +129,8 @@ namespace SelfGuidedTours.Tests.UnitTests
             refreshTokenValidator = new RefreshTokenValidator();
             refreshTokenService = new RefreshTokenService(repository);
             logger = new Logger<AuthService>(loggerFactory);
-            var mockedBloblService = new Mock<IBlobService>();
+            var mockedBloblService = new Mock<IBlobService>();      
             profileService = new ProfileService(repository, mockUserManager.Object,mockedBloblService.Object);
-
             // AuthService initialized
             service = new AuthService(repository, accessTokenGenerator,
                 refreshTokenGenerator, refreshTokenValidator, refreshTokenService, profileService, mockUserManager.Object, logger);


### PR DESCRIPTION
Added a new status—'Deleted'—to facilitate the handling of soft-deleted tours on the 'My Tours' page. Also implemented the logic and the endpoint 'api/Profile/delete-my-tour/{id}'.